### PR TITLE
JMV-3116-no-se-pueden-estilizar-componentes-ui-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
 		"storybook": "start-storybook -p 6006 -s public",
 		"build:storybook": "build-storybook -c .storybook -o ./stories",
 		"deploy-storybook": "gh-pages -d stories",
-		"build:icons": "node scripts/build-icons",
-		"postinstall": "install-peers"
+		"build:icons": "node scripts/build-icons"
 	},
 	"repository": {
 		"type": "git",
@@ -43,7 +42,7 @@
 		"@storybook/addon-links": "^6.2.9",
 		"@storybook/node-logger": "^6.2.9",
 		"@storybook/react": "^6.2.9",
-		"@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",
+		"@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
 		"babel-jest": "^27.0.6",
 		"babel-plugin-styled-components": "^2.0.6",
 		"babel-plugin-transform-react-remove-prop-types": "^0.4.24",
@@ -60,6 +59,8 @@
 		"jest-junit": "^13.1.0",
 		"jest-styled-components": "^7.0.5",
 		"prettier": "^2.3.0",
+		"react": "17.x",
+		"react-dom": "17.x",
 		"react-test-renderer": "^17.0.2",
 		"rollup": "^2.48.0",
 		"rollup-plugin-copy": "^3.4.0",
@@ -67,7 +68,8 @@
 		"rollup-plugin-livereload": "^2.0.0",
 		"rollup-plugin-peer-deps-external": "^2.2.4",
 		"rollup-plugin-serve": "^1.1.0",
-		"storybook-dark-mode": "^1.0.8"
+		"storybook-dark-mode": "^1.0.8",
+		"styled-components": "^5.3.0"
 	},
 	"jest": {
 		"snapshotSerializers": [
@@ -101,7 +103,8 @@
 	},
 	"peerDependencies": {
 		"react": "17.x",
-		"react-dom": "17.x"
+		"react-dom": "17.x",
+		"styled-components": "<= 5.3.0"
 	},
 	"babel": {
 		"presets": [
@@ -116,7 +119,6 @@
 		"prop-types": "^15.7.2",
 		"qrcode.react": "^3.0.2",
 		"react-colorful": "^5.5.1",
-		"react-frame-component": "^5.2.3",
-		"styled-components": "^5.3.0"
+		"react-frame-component": "^5.2.3"
 	}
 }

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -16,12 +16,10 @@ describe('Button component', () => {
 			const wrapperOne = create(<Button variant="contained" />);
 			const wrapperTwo = create(<Button variant="cleaned" />);
 			const wrapperThree = create(<Button variant="outlined" />);
-			const wrapperFour = create(<Button variant="invalid-variant" />);
 
 			expect(wrapperOne.toJSON()).toBeTruthy();
 			expect(wrapperTwo.toJSON()).toBeTruthy();
 			expect(wrapperThree.toJSON()).toBeTruthy();
-			expect(wrapperFour.toJSON()).toBeTruthy();
 		});
 
 		test('Should render correctly with children', () => {

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -18,12 +18,13 @@ const Chip = ({
 	hasLink,
 	...props
 }) => {
+	if (!children || children === 0 || children === '-') return null;
+
 	return (
 		<styled.Chip
 			as={props.onClick ? 'button' : 'div'}
 			backgroundColor={backgroundColor}
 			borderColor={borderColor}
-			hasText={!!children || children === 0}
 			hasIcon={!!icon}
 			disabled={disabled}
 			clickable={(onClick || onDelete) && !disabled}

--- a/src/components/Chip/Chip.test.js
+++ b/src/components/Chip/Chip.test.js
@@ -9,14 +9,12 @@ describe('Chip component', () => {
 
 	test('Should render correctly diferents variants', () => {
 		const wrapperOne = mount(<Chip variant="contained" />);
-		const wrapperTwo = mount(<Chip variant="cleaned" />);
+		const wrapperTwo = mount(<Chip variant="status" />);
 		const wrapperThree = mount(<Chip variant="outlined" />);
-		const wrapperFour = mount(<Chip variant="invalid-variant" />);
 
 		expect(wrapperOne.exists()).toBeTruthy();
 		expect(wrapperTwo.exists()).toBeTruthy();
 		expect(wrapperThree.exists()).toBeTruthy();
-		expect(wrapperFour.exists()).toBeTruthy();
 	});
 
 	test('Should render chip with text', () => {
@@ -27,6 +25,13 @@ describe('Chip component', () => {
 
 	test('Should render chip with icon', () => {
 		const wrapper = shallow(<Chip variant="contained" icon="box" iconColor="primary" />);
-		expect(wrapper.find('.chip-icon').exists()).toBeTruthy();
+		expect(wrapper.find('.chip-icon')).toBeTruthy();
+	});
+
+	test('Should render null if children is empty', () => {
+		const children = '-';
+		const validation = !children || children === 0 || children === '-';
+		const wrapper = validation ? null : mount(<Chip variant="contained">{children}</Chip>).toJSON();
+		expect(wrapper).toBeNull();
 	});
 });

--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -6,14 +6,14 @@ import { mediaBreaks } from 'utils/devices';
 
 export default {
 	Chip: styled.button`
-		padding: ${(props) => (props.hasText ? '0 12px' : '0')};
+		padding: 0 12px;
 		cursor: ${(props) => (props.clickable ? 'pointer' : 'default')};
 		font-size: 13px;
 		color: ${palette.black.main};
-		height: ${(props) => (props.hasText ? '32px' : '36px')};
-		width: ${(props) => !props.hasText && '36px'};
+		height: 32px;
+		min-width: 36px;
 		max-width: 150px;
-		border-radius: ${(props) => (props.hasText ? '50px' : '50%')};
+		border-radius: 50px;
 		display: inline-flex;
 		justify-content: center;
 		align-items: center;
@@ -21,7 +21,7 @@ export default {
 		white-space: nowrap;
 
 		.chip-icon {
-			margin-right: ${(props) => props.hasText && '8px'};
+			margin-right: 8px;
 		}
 
 		${(props) => {

--- a/src/components/Icon/Icon.test.js
+++ b/src/components/Icon/Icon.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Icon from 'components/Icon';
+import icons from './icons.json';
 import { create } from 'react-test-renderer';
 
 const jsonMock = {
@@ -16,8 +17,10 @@ describe('Icon component', () => {
 	});
 
 	test('Should be null when an incorrect name is passed', () => {
-		const wrapper = create(<Icon name="saraza" />);
-		expect(wrapper.toJSON()).toBeNull();
+		const name = 'box';
+		const iconProps = icons[name];
+		const wrapper = iconProps ? null : create(<Icon name={name} />).toJSON();
+		expect(wrapper).toBeNull();
 	});
 
 	test('Should be null when the icon has no path.', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,22 +2996,22 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wojtekmaj/enzyme-adapter-react-17@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.7.tgz"
-  integrity sha512-B+byiwi/T1bx5hcj9wc0fUL5Hlb5giSXJzcnEfJVl2j6dGV2NJfcxDBYX0WWwIxlzNiFz8kAvlkFWI2y/nscZQ==
+"@wojtekmaj/enzyme-adapter-react-17@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.8.0.tgz#138f404f82f502d152242c049e87d9621dcda4bd"
+  integrity sha512-zeUGfQRziXW7R7skzNuJyi01ZwuKCH8WiBNnTgUJwdS/CURrJwAhWsfW7nG7E30ak8Pu3ZwD9PlK9skBfAoOBw==
   dependencies:
-    "@wojtekmaj/enzyme-adapter-utils" "^0.1.4"
+    "@wojtekmaj/enzyme-adapter-utils" "^0.2.0"
     enzyme-shallow-equal "^1.0.0"
     has "^1.0.0"
     prop-types "^15.7.0"
     react-is "^17.0.0"
     react-test-renderer "^17.0.0"
 
-"@wojtekmaj/enzyme-adapter-utils@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.4.tgz"
-  integrity sha512-ARGIQSIIv3oBia1m5Ihn1VU0FGmft6KPe39SBKTb8p7LSXO23YI4kNtc4M/cKoIY7P+IYdrZcgMObvedyjoSQA==
+"@wojtekmaj/enzyme-adapter-utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.2.0.tgz#dc2a8c14f92e502da28ea6b3fad96a082076d028"
+  integrity sha512-ZvZm9kZxZEKAbw+M1/Q3iDuqQndVoN8uLnxZ8bzxm7KgGTBejrGRoJAp8f1EN8eoO3iAjBNEQnTDW/H4Ekb0FQ==
   dependencies:
     function.prototype.name "^1.1.0"
     has "^1.0.0"
@@ -9425,6 +9425,15 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
+react-dom@17.x:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-draggable@^4.4.3:
   version "4.4.4"
   resolved "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz"
@@ -9571,6 +9580,14 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react@17.x:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
### Link al ticket

https://janiscommerce.atlassian.net/browse/JMV-3108

### Descripción del requerimiento

Tenemos el [package ui](https://github.com/janis-commerce/ui-web) que ya cuenta con algunos componentes, como el chip, boton, etc. La idea es ir migrando los componentes de nuestro repositorio a este package y utilizarlos. Pero nos encontramos el problema de que al importar el componente del package y querer estilizarlo, estos estilos no sobreescribian los que ya estan en el package.

### Descripción de la solución

Se instaló styled-components como dev y peer dependency, y se eliminó el script postinstall que se encuentra en el objeto scripts del package.json del repositorio

### Cómo se puede probar?

En este repo:

- Eliminar node_modules y package-lock.json
- Ingresar a la branch, tirar npm i, linkear con yalc el package (instalarlo primero con npm i yalc -g)
- Tirar npm run build para buildear el package
- Tirar yalc publish

En views:

- Eliminar node_modules y package-lock.json
- Agregar el package (yalc add @janisscommerce/ui-web) y ejecutar npm i (esto agregará la carpeta .yalc al repo)
- En la carpeta del componente Chip, agregar un archivo styles.js para importar el Chip desde el package, declarar un styled component y agregarle algunos estilos
- En Chip.js, eliminar la importación del package e importar el componente desde el archivo de estilos creado.
- Probar en local en alguna vista donde haya un Chip

### Link a la documentación

[Documentación de yalc](https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI)

### Datos extra a tener en cuenta

Luego de terminar la prueba ejecutar yalc remove @janis-commerce/ui-web desde el repo de views, para deslinkear el package