### PR TITLE
Validate Chip with Icon

### DIFF
--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -18,7 +18,7 @@ const Chip = ({
 	hasLink,
 	...props
 }) => {
-	if (!children) return null;
+	if (!children && !icon) return null;
 
 	return (
 		<styled.Chip
@@ -34,6 +34,7 @@ const Chip = ({
 			variant={variant}
 			iconColor={iconColor}
 			hasLink={hasLink}
+			onlyIcon={!children && icon}
 			{...props}
 		>
 			{icon && (
@@ -44,7 +45,7 @@ const Chip = ({
 					pathStyles={styled.iconPathStyles}
 				/>
 			)}
-			<styled.Children>{children}</styled.Children>
+			{children && <styled.Children>{children}</styled.Children>}
 			{onDelete && (
 				<styled.DeleteButton type="button" onClick={onDelete}>
 					<Icon

--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -6,7 +6,7 @@ import { mediaBreaks } from 'utils/devices';
 
 export default {
 	Chip: styled.button`
-		padding: 0 12px;
+		padding: ${(props) => (!props.onlyIcon ? '0 12px' : '0')};
 		cursor: ${(props) => (props.clickable ? 'pointer' : 'default')};
 		font-size: 13px;
 		color: ${palette.black.main};
@@ -21,7 +21,7 @@ export default {
 		white-space: nowrap;
 
 		.chip-icon {
-			margin-right: 8px;
+			${(props) => !props.onlyIcon && 'margin-right: 8px'};
 		}
 
 		${(props) => {


### PR DESCRIPTION
## Descripción del requerimiento

Se encontró un caso donde el chip está renderizando un ícono y está mostrando el texto "false" al lado del mismo

## Descripción de la solución

- Se modificó la validación `if (!children) return null;` a `if (!children && !icon) return null;`
- Se agregó la validación de `children` para el render del `styled.Children`
- 
## Cómo se puede probar?

Linkear el package y Views, probar en vistas donde haya varios casos de chip, especialmente un chip con icono (Ej.: http://janis.localhost:3001/picking/wave/browse)