### PR TITLE
JMV-3283-implementar-drawer-ui-web

### DIFF
--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import Icon from 'components/Icon';
+import styled from './styles';
+
+const Modal = ({ open, position, handleClose, transitionDuration, children }) => {
+	const [drawerWidthOnClose, setDrawerWidthOnClose] = useState('0');
+
+	// useEffect to check the drawer width when drawer__content is closed
+	useEffect(() => {
+		const drawerContentEl = document.querySelector('.drawer__content');
+		if (!drawerContentEl) return;
+		const setWrapperWidth = () => {
+			const isContentVisible = drawerContentEl.checkVisibility({ checkVisibilityCSS: true });
+			setDrawerWidthOnClose(isContentVisible ? '100%' : '0');
+		};
+		drawerContentEl.addEventListener('transitionend', setWrapperWidth);
+	}, []);
+
+	const drawerStyles = {
+		...(open && { width: '100%' }),
+		...(!open && { width: drawerWidthOnClose }),
+		...((position === 'right' || position === 'left') && {
+			top: 0
+		}),
+		[position]: 0
+	};
+
+	const overlayStyles = {
+		zIndex: 100
+	};
+
+	const contentStyles = {
+		zIndex: overlayStyles.zIndex + 1
+	};
+
+	return (
+		<styled.Drawer className="drawer" style={drawerStyles}>
+			<styled.Checkbox
+				type="checkbox"
+				id="drawer__checkbox"
+				checked={open}
+				onChange={handleClose}
+			/>
+			<styled.Content
+				open={open}
+				position={position}
+				transitionDuration={transitionDuration}
+				className="drawer__content"
+				style={contentStyles}
+			>
+				<styled.Header>
+					{handleClose && typeof handleClose === 'function' && (
+						<styled.CloseBtn onClick={handleClose}>
+							<Icon className="close-btn" name="cross_light" width={24} height={24} />
+						</styled.CloseBtn>
+					)}
+				</styled.Header>
+				<styled.Children>{children}</styled.Children>
+			</styled.Content>
+			<styled.Overlay
+				htmlFor="drawer__checkbox"
+				className="drawer__overlay"
+				style={overlayStyles}
+			/>
+		</styled.Drawer>
+	);
+};
+
+export default Modal;
+
+Modal.propTypes = {
+	open: PropTypes.bool,
+	position: PropTypes.string,
+	handleClose: PropTypes.func,
+	transitionDuration: PropTypes.number,
+	children: PropTypes.node
+};
+
+Modal.defaultProps = {
+	open: false,
+	position: 'right',
+	handleClose: () => {},
+	transitionDuration: 500
+};

--- a/src/components/Drawer/Drawer.stories.js
+++ b/src/components/Drawer/Drawer.stories.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import Drawer from './Drawer';
+
+const control = {
+	type: 'select',
+	options: ['top', 'right', 'bottom', 'left']
+};
+
+export default {
+	title: 'Components/Drawer',
+	component: Drawer,
+	parameters: {
+		layout: 'centered'
+	},
+	argTypes: {
+		position: { control }
+	}
+};
+
+const Template = (args) => {
+	return (
+		<div
+			style={{
+				position: 'relative',
+				width: '500px',
+				height: '500px',
+				backgroundColor: '#C4C6CC',
+				border: '1px solid black',
+				overflow: 'hidden'
+			}}
+		>
+			<Drawer {...args} handleClose={null} />
+		</div>
+	);
+};
+
+const TemplateWithHeader = (args) => {
+	const [isOpen, setIsOpen] = React.useState(false);
+	const toggleDrawer = () => {
+		setIsOpen(!isOpen);
+	};
+
+	return (
+		<div
+			style={{
+				width: '1000px',
+				height: '600px',
+				backgroundColor: '#C4C6CC',
+				border: '1px solid black',
+				overflow: 'hidden'
+			}}
+		>
+			<div
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					width: '100%',
+					height: '100px',
+					backgroundColor: '#5393FF',
+					color: '#FFFFFF',
+					fontWeight: 'bold',
+					textTransform: 'uppercase'
+				}}
+			>
+				Header
+			</div>
+			<div style={{ position: 'relative', height: '500px' }}>
+				<div>
+					<button onClick={toggleDrawer}>abrir</button>
+				</div>
+				<Drawer {...args} open={isOpen} handleClose={toggleDrawer}>
+					<div style={{ display: 'flex', flexDirection: 'column' }}>
+						<div style={{ marginTop: '10px' }}>
+							<span style={{ display: 'block', marginBottom: '10px' }}>Conductor</span>
+							<select>
+								<option value="">Opción 1</option>
+								<option value="">Opción 2</option>
+								<option value="">Opción 3</option>
+							</select>
+						</div>
+						<div style={{ marginTop: '10px' }}>
+							<span style={{ display: 'block', marginBottom: '10px' }}>Tienda</span>
+							<select>
+								<option value="">Opción 1</option>
+								<option value="">Opción 2</option>
+								<option value="">Opción 3</option>
+							</select>
+						</div>
+						<div style={{ marginTop: '10px' }}>
+							<span style={{ display: 'block', marginBottom: '10px' }}>Fecha</span>
+							<select>
+								<option value="">Opción 1</option>
+								<option value="">Opción 2</option>
+								<option value="">Opción 3</option>
+							</select>
+						</div>
+					</div>
+					<div style={{ marginTop: '30px' }}>
+						<button>Agregar</button>
+					</div>
+				</Drawer>
+			</div>
+		</div>
+	);
+};
+
+const baseArgs = {
+	open: false,
+	position: 'right',
+	handleClose: () => {},
+	transitionDuration: 500,
+	children: 'This is a drawer'
+};
+
+export const Base = Template.bind({});
+export const WithHeader = TemplateWithHeader.bind({});
+
+Base.args = {
+	...baseArgs
+};
+
+WithHeader.args = {
+	...baseArgs
+};

--- a/src/components/Drawer/index.js
+++ b/src/components/Drawer/index.js
@@ -1,0 +1,1 @@
+export { default } from './Drawer';

--- a/src/components/Drawer/styles.js
+++ b/src/components/Drawer/styles.js
@@ -1,0 +1,113 @@
+import styled, { css } from 'styled-components';
+import Button from 'components/Button';
+
+const setPosition = (position, open) => {
+	switch (position) {
+		case 'top':
+			return css`
+				width: 100%;
+				height: unset;
+				left: 0;
+				right: 0;
+				top: 0;
+				transform: ${open ? 'translateY(0)' : 'translateY(-100%)'};
+			`;
+		case 'bottom':
+			return css`
+				width: 100%;
+				height: unset;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				transform: ${open ? 'translateY(0)' : 'translateY(100%)'};
+			`;
+		case 'left':
+			return css`
+				top: 0;
+				left: 0;
+				transform: ${open ? 'translateX(0)' : 'translateX(-100%)'};
+			`;
+		default:
+			return css`
+				top: 0;
+				right: 0;
+				transform: ${open ? 'translateX(0)' : 'translateX(100%)'};
+			`;
+	}
+};
+
+const Drawer = styled.div`
+	position: absolute;
+	height: 100%;
+	display: flex;
+	justify-content: center;
+`;
+
+const Checkbox = styled.input`
+	display: none;
+
+	&:checked {
+		& ~ .drawer__overlay {
+			display: block;
+			opacity: 1;
+		}
+
+		& ~ .drawer__content {
+			visibility: visible;
+		}
+	}
+`;
+
+const Overlay = styled.label`
+	display: none;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	left: 0;
+	top: 0;
+`;
+
+const Content = styled.div`
+	position: absolute;
+	visibility: hidden;
+	background-color: #ffffff;
+	box-sizing: border-box;
+	min-width: 200px;
+	height: 100%;
+	${({ position, open }) => setPosition(position, open)};
+	${({ transitionDuration }) =>
+		transitionDuration &&
+		`transition: all ${transitionDuration / 1000}s cubic-bezier(0.82, 0.085, 0.395, 0.895)`};
+	padding: 16px 28px 32px 32px;
+	border-radius: 3px;
+	box-shadow: 0px 2px 5px 0px #27394727;
+`;
+
+const Header = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+`;
+
+const CloseBtn = styled(Button)`
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	background-color: transparent;
+	border-radius: 0;
+	outline: 0;
+	margin-left: auto;
+`;
+
+const Children = styled.div``;
+
+export default {
+	Drawer,
+	Checkbox,
+	Overlay,
+	Content,
+	Header,
+	CloseBtn,
+	Children
+};


### PR DESCRIPTION
### Link al ticket
[https://janiscommerce.atlassian.net/browse/JMV-3275](https://janiscommerce.atlassian.net/browse/JMV-3275)

### Descripción del requerimiento
Implementar un componente Drawer de forma agnóstica en el repositorio [ui-web](https://github.com/janis-commerce/ui-web)

### Descripción de la solución
Se creo el componente Drawer, tanto la lógica, los estilos y su presentación en Storybook

La configuración del componente agregada es la siguiente:
- el componente puede recibir cualquier cosa como children
- la position del drawer puede ser top, bottom, left o right. Por defecto es right
- puede recibir la duracion de la transicion (en ms) cuando se abre o se cierra el drawer
- la cruz del drawer se muestra sólo cuando recibe un handler para cerrar el mismo

### ¿Cómo se puede probar?
- Ingresar a la branch
- Levantar storybook (`yarn storybook`) para revisar el componente y sus controles

En storybook hay dos ejemplos de drawer, uno simple y otro con header.
- El primero se utiliza con los controles
- En el segundo ejemplo el drawer sólo debe aparecer en el body, sin tapar el header y que este último pueda ser clickeable. Cuando el drawer esté abierto, los elementos del body no pueden ser clickeables.

https://www.loom.com/share/ab58496ff2cb404885fd54bb92f3e93b?sid=f8e07479-4df1-493b-b508-6fc5bffd0645