### PR TITLE
fontColor and iconColor fix

### DIFF
--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -33,7 +33,6 @@ const Template = (args) => <Button {...args} />;
 const baseArgs = {
 	children: 'Button',
 	hideLabel: false,
-	iconColor: 'black',
 	iconSize: 24,
 	rounded: false,
 	variant: 'contained'

--- a/src/components/Button/utils.js
+++ b/src/components/Button/utils.js
@@ -29,10 +29,10 @@ export const getHoverColor = (color) =>
 export const getPressedColor = (color) =>
 	isValidColor(color) ? viewsPalette[`${color}Pressed`] : bluePressed;
 
-const commonStyles = (iconColor, fontColor) => css`
-	color: ${findColorInTheme(fontColor || blue)};
+const commonStyles = (iconColor, fontColor, color) => css`
+	color: ${findColorInTheme(fontColor || color || blue)};
 	.button-icon {
-		fill: ${findColorInTheme(iconColor || blue)};
+		fill: ${findColorInTheme(iconColor || color || blue)};
 	}
 	background: none;
 	&:focus,
@@ -75,10 +75,10 @@ export const getButtonStyles = ({ fontColor, color, variant, iconColor }) => {
 			}
 		`,
 		outlined: () => css`
-			${commonStyles(color)};
+			${commonStyles(iconColor, fontColor, color)};
 			border: 1px solid ${findColorInTheme(grey)};
 		`,
-		cleaned: () => commonStyles(iconColor, fontColor)
+		cleaned: () => commonStyles(iconColor, fontColor, color)
 	};
 
 	return variantStyles[variant] || '';


### PR DESCRIPTION
**Link al ticket**
https://janiscommerce.atlassian.net/browse/JMV-2773

**Descripción del requerimiento**
En base al desarrollo, se encontró un botón que no tomaba bien el color 
![image](https://github.com/janis-commerce/ui-web/assets/64233677/830c07f5-9a79-4cf2-a991-847633973985)

Esto sucede en todos los ambientes ya que se subió a master, en creación de ordenes, al seleccionar algún producto aparece ese botón

https://app.janisdev.in/oms/order/new

**Descripción de la solución**

- En base a lo revisado esto sucede porque desde el utils del botón acá en ui web, no estamos mandando a la función commonProps, ni iconColor ni fontColor, esto hace que no pueda modificarse el color con dichas props
- Se corrigió para que tome como prioridad el fontColor, sino el color y como default el blue de janis para variantes outlined y cleaned
- De esta manera si no pasamos ninguna prop, va a tomar el color por default el icono y la fuente

**Cómo se puede probar?**
En este repo
- Levantando la rama
- Eliminando node_modules
- Corriendo comando yarn
- Luego yarn build
- Finalmente yalc publish

En Views

- Levantar master o cualquier rama
- Borrar node_modules
- Correr comando yalc add @janiscommerce/ui-web
- Correr npm i
- Levantar el docker

Al momento de crear una orden, y seleccionar un producto, el botón debería verse rojo
![image](https://github.com/janis-commerce/ui-web/assets/64233677/3e6be5ce-4e51-41a2-87c3-105eb8abc163)

Además revisar los demas botones outlined, yo revise y no vi errores
Yo revise los outlined de edit(cancel), los de las actions, el que tenemos en el componente code, el del DatePicker, cancel de filtros, modales
