### PR TITLE
add components documentation data

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -48,9 +48,11 @@ Checkbox.propTypes = {
 	defaultChecked: PropTypes.bool,
 	/** Callback disparado al cambiar el valor de checked */
 	onChange: PropTypes.func,
+	/** Si es true, redondea el componente */
 	rounded: PropTypes.bool,
 	/** Si es true, deshabilita el componente */
 	disabled: PropTypes.bool,
+	/** Permite aplicar estilos adicionales */
 	styles: PropTypes.shape({}),
 	/** Valor del componente en caso de mostrar contenido ya existente */
 	value: PropTypes.oneOfType([PropTypes.bool, PropTypes.number])

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -101,8 +101,7 @@ Chip.defaultProps = {
 	selected: false,
 	textColor: '',
 	variant: 'outlined',
-	hasLink: false,
-	onDelete: false
+	hasLink: false
 };
 
 export default Chip;

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -62,23 +62,34 @@ const Chip = ({
 };
 
 Chip.propTypes = {
+	/** Permite cambiar el color de fondo del componente */
 	backgroundColor: PropTypes.string,
+	/** Permite modificar el color del borde del componente */
 	borderColor: PropTypes.string,
+	/** Hijo del componente */
 	children: PropTypes.node,
-	// Si es true deshabilita el chip
+	/** Si es true deshabilita el chip */
 	disabled: PropTypes.bool,
+	/** Icono a mostrar dentro del chip */
 	icon: PropTypes.string,
+	/** Permite modificar el color del icono */
 	iconColor: PropTypes.string,
+	/** Función a ejecutar al clickar */
 	onClick: PropTypes.func,
+	/** Función a ejecutar para borrar */
 	onDelete: PropTypes.func,
-	// Si es true mantiene el chip seleccionado
+	/** Si es true mantiene el chip seleccionado */
 	selected: PropTypes.bool,
+	/** Permite aplicar estilos adicionales */
 	styles: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.func]))
 	]),
+	/** Permite modificar el color del texto */
 	textColor: PropTypes.string,
+	/** Permite seleccionar las distintas variantes del componente */
 	variant: PropTypes.oneOf(['contained', 'outlined', 'status']),
+	/** Si es true aplica eventos de link */
 	hasLink: PropTypes.bool
 };
 
@@ -90,7 +101,8 @@ Chip.defaultProps = {
 	selected: false,
 	textColor: '',
 	variant: 'outlined',
-	hasLink: false
+	hasLink: false,
+	onDelete: false
 };
 
 export default Chip;

--- a/src/components/Chip/Chip.stories.js
+++ b/src/components/Chip/Chip.stories.js
@@ -34,15 +34,7 @@ const Template = (args) => <Chip {...args} />;
 
 const baseArgs = {
 	children: 'Chip',
-	backgroundColor: 'grey',
-	borderColor: 'black',
-	disabled: false,
-	icon: 'box',
-	iconColor: 'black',
-	selected: false,
-	textColor: 'black',
 	variant: 'contained',
-	hasLink: false,
 	onDelete: false
 };
 
@@ -51,8 +43,7 @@ export const Outlined = Template.bind({});
 export const Status = Template.bind({});
 
 Contained.args = {
-	...baseArgs,
-	color: 'red'
+	...baseArgs
 };
 
 Outlined.args = {

--- a/src/components/Chip/Chip.stories.js
+++ b/src/components/Chip/Chip.stories.js
@@ -22,7 +22,6 @@ export default {
 		backgroundColor: { control },
 		textColor: { control },
 		borderColor: { control },
-		color: { control },
 		iconColor: { control },
 		icon: {
 			type: 'select',
@@ -35,7 +34,15 @@ const Template = (args) => <Chip {...args} />;
 
 const baseArgs = {
 	children: 'Chip',
+	backgroundColor: 'grey',
+	borderColor: 'black',
+	disabled: false,
+	icon: 'box',
+	iconColor: 'black',
+	selected: false,
+	textColor: 'black',
 	variant: 'contained',
+	hasLink: false,
 	onDelete: false
 };
 

--- a/src/components/Chip/Chip.stories.js
+++ b/src/components/Chip/Chip.stories.js
@@ -22,6 +22,7 @@ export default {
 		backgroundColor: { control },
 		textColor: { control },
 		borderColor: { control },
+		color: { control },
 		iconColor: { control },
 		icon: {
 			type: 'select',
@@ -34,15 +35,7 @@ const Template = (args) => <Chip {...args} />;
 
 const baseArgs = {
 	children: 'Chip',
-	backgroundColor: 'grey',
-	borderColor: 'black',
-	disabled: false,
-	icon: 'box',
-	iconColor: 'black',
-	selected: false,
-	textColor: 'black',
 	variant: 'contained',
-	hasLink: false,
 	onDelete: false
 };
 

--- a/src/components/Color/Color.js
+++ b/src/components/Color/Color.js
@@ -17,7 +17,9 @@ const Color = ({ color, showLabel }) => {
 };
 
 Color.propTypes = {
+	/** Permite modificar el color del componente */
 	color: PropTypes.string,
+	/** Si es true, muestra el código del color */
 	showLabel: PropTypes.bool
 };
 

--- a/src/components/ColorPicker/ColorPicker.js
+++ b/src/components/ColorPicker/ColorPicker.js
@@ -59,10 +59,14 @@ const ColorPicker = ({ color, isCollapsable, onChange, errorMessage, error }) =>
 };
 
 ColorPicker.propTypes = {
+	/** Código del color */
 	color: PropTypes.string,
 	onChange: PropTypes.func,
+	/** Agrega un input con el código del color */
 	isCollapsable: PropTypes.bool,
+	/** Si es true, el input del colapsable aparece con error */
 	error: PropTypes.bool,
+	/** Texto a mostrar en caso de error */
 	errorMessage: PropTypes.string
 };
 

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -11,7 +11,8 @@ const Drawer = ({
 	transitionDuration,
 	fullScreen,
 	closeOnClickAway,
-	children
+	children,
+	...props
 }) => {
 	const drawerRef = useRef(null);
 
@@ -25,6 +26,7 @@ const Drawer = ({
 					fullScreen={fullScreen}
 					className="drawer"
 					ref={drawerRef}
+					{...props}
 				>
 					<styled.Content className="drawer__content">
 						<styled.Header>

--- a/src/components/QRCode/QRCode.js
+++ b/src/components/QRCode/QRCode.js
@@ -9,7 +9,9 @@ const QRCode = ({ value, size }) => {
 };
 
 QRCode.propTypes = {
+	/** Url hacia donde dirige el QR */
 	value: PropTypes.string.isRequired,
+	/** Permite modificar el tamaño del componente */
 	size: PropTypes.number
 };
 

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -127,6 +127,7 @@ Textarea.propTypes = {
 	hasFloatingLabel: PropTypes.bool,
 	/** Atributo name del elemento textarea */
 	name: PropTypes.string,
+	/** Valor del floating label */
 	label: PropTypes.string,
 	/** Callback disparado cuando se sale del foco del textarea */
 	onBlur: PropTypes.func,


### PR DESCRIPTION
**Link al ticket**
No hay

**Descripción del requerimiento**

- Al revisar PRs encontre que no estan documentadas las props de varios componentes
- Se requiere que en la solapa docs de storybooks, se vea descripción de que hace cada prop
- Poder estilizar el Drawer desde Views o donde lo usemos

**Descripción de la solución**

- Se aplicó en varios componentes la documentación de cada prop para que se vea en storybook
- Además agregamos la variante correcta al Chip en sotrie ya que tenia un error
- Se agregó el props destrucurado en Drawer para poder estilizarlo desde Views

**¿Cómo se puede probar?**

- Ingresando a la rama, levantando storybook (**yarn storybook**)
- Ingresando en cada uno de los componentes y validando que todas las props tengan su descripción

**Screenshot**
![image](https://github.com/janis-commerce/ui-web/assets/64233677/2cc34b7c-170c-49ed-ae53-5a76549ed576)
![image](https://github.com/janis-commerce/ui-web/assets/64233677/a72e0c0b-c8fd-4172-b894-11078cb19326)
![image](https://github.com/janis-commerce/ui-web/assets/64233677/1e7a676e-a128-44ba-bc1f-22b942a5514c)

