### PR TITLE
Jmv 3315 crear componente avatar en UI web

### DIFF
--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -23,7 +23,7 @@ const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 
 	const getInitials = () => {
 		try {
-			const initials = getInitialsTheme(firstname, lastname, mainColor);
+			const initials = getInitialsTheme(firstname, lastname);
 
 			if (initials) setInitialsData(initials);
 			else setImage(defaultUserImage);

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import useDevices from 'hooks/useDevices';
 import { getImageMeasurements } from 'theme/utils';
+import Skeleton from 'components/Skeleton';
 import styled from './styles';
 import { getInitialsTheme, getUserColor } from './utils';
-import Skeleton from 'react-loading-skeleton';
 
 const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 	const [loading, setLoading] = useState(true);

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import useDevices from 'hooks/useDevices';
+import { getImageMeasurements } from 'theme/utils';
+import styled from './styles';
+import { getInitialsTheme, getUserColor } from './utils';
+
+const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
+	const [image, setImage] = useState(url);
+	const [initialsData, setInitialsData] = useState();
+
+	const { onlyDesktop } = useDevices();
+
+	const initials = getInitialsTheme(firstname, lastname) || null;
+	const imageSize = getImageMeasurements(size, onlyDesktop);
+
+	const defaultUserImage = `https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y${
+		imageSize && `&s=${imageSize}`
+	}`;
+
+	const getInitials = () => (initials ? setInitialsData(initials) : setImage(defaultUserImage));
+
+	return !initialsData ? (
+		<styled.Image
+			src={url || image}
+			alt={`${firstname} ${lastname}`}
+			onError={getInitials}
+			size={imageSize}
+			rounded={rounded}
+		/>
+	) : (
+		<styled.Initials color={mainColor || getUserColor(initials)} size={imageSize} rounded={rounded}>
+			{initialsData}
+		</styled.Initials>
+	);
+};
+
+Avatar.propTypes = {
+	/** Nombre del usuario */
+	firstname: PropTypes.string,
+	/** Apellido del usuario */
+	lastname: PropTypes.string,
+	/** Color del fondo para el Avatar de texto */
+	mainColor: PropTypes.string,
+	/** Medida de alto y ancho para la imagen en pixeles */
+	size: PropTypes.oneOfType([
+		PropTypes.oneOf(['small', 'medium', 'large', 'extralarge', 'auto']),
+		PropTypes.number
+	]),
+	/** Si esta activa redondea el Avatar */
+	rounded: PropTypes.bool,
+	/** URL de donde  se carga la imagen del Avatar */
+	url: PropTypes.string
+};
+
+Avatar.defaultProps = {
+	firstname: '',
+	lastname: '',
+	size: 'small',
+	url: '',
+	rounded: true
+};
+
+export default Avatar;

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -4,8 +4,11 @@ import useDevices from 'hooks/useDevices';
 import { getImageMeasurements } from 'theme/utils';
 import styled from './styles';
 import { getInitialsTheme, getUserColor } from './utils';
+import Skeleton from 'react-loading-skeleton';
 
 const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
+	const [loading, setLoading] = useState(true);
+
 	const [image, setImage] = useState(url);
 	const [initialsData, setInitialsData] = useState();
 
@@ -21,13 +24,18 @@ const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 	const getInitials = () => (initials ? setInitialsData(initials) : setImage(defaultUserImage));
 
 	return !initialsData ? (
-		<styled.Image
-			src={url || image}
-			alt={`${firstname} ${lastname}`}
-			onError={getInitials}
-			size={imageSize}
-			rounded={rounded}
-		/>
+		<>
+			<styled.Image
+				src={url || image}
+				alt={`${firstname} ${lastname}`}
+				onError={getInitials}
+				onLoad={() => setLoading(false)}
+				show={!loading}
+				size={imageSize}
+				rounded={rounded}
+			/>
+			{loading && <Skeleton circle={rounded} width={imageSize} height={imageSize} />}
+		</>
 	) : (
 		<styled.Initials color={mainColor || getUserColor(initials)} size={imageSize} rounded={rounded}>
 			{initialsData}

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,16 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useDevices from 'hooks/useDevices';
 import { getImageMeasurements } from 'theme/utils';
 import Skeleton from 'components/Skeleton';
 import styled from './styles';
-import { getInitialsTheme, getUserColor } from './utils';
+import { getInitialsTheme } from './utils';
+import InitialsAvatar from './components/InitialsAvatar';
 
 const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
-	const [loading, setLoading] = useState(true);
+	const imageRef = useRef();
 
-	const [image, setImage] = useState(url);
-	const [initialsData, setInitialsData] = useState();
+	const [loading, setLoading] = useState(true);
+	const [showInitials, setShowInitials] = useState(false);
 
 	const { onlyDesktop } = useDevices();
 
@@ -23,23 +24,28 @@ const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 
 	const getInitials = () => {
 		try {
-			const initials = getInitialsTheme(firstname, lastname);
-
-			if (initials) setInitialsData(initials);
-			else setImage(defaultUserImage);
+			if (!initials) throw new Error('First or lastname not provided');
+			return setShowInitials(true);
 		} catch {
-			setImage(defaultUserImage);
+			imageRef.current.src = defaultUserImage;
 		}
 	};
 
-	useEffect(() => {
-		if (url) setImage(url);
-	}, [url]);
+	if (showInitials)
+		return (
+			<InitialsAvatar
+				initials={initials}
+				mainColor={mainColor}
+				imageSize={imageSize}
+				rounded={rounded}
+			/>
+		);
 
-	return !initialsData ? (
+	return (
 		<>
 			<styled.Image
-				src={image}
+				ref={imageRef}
+				src={url}
 				alt={`${firstname} ${lastname}`}
 				onError={getInitials}
 				onLoad={() => setLoading(false)}
@@ -49,10 +55,6 @@ const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 			/>
 			{loading && <Skeleton circle={rounded} width={imageSize} height={imageSize} />}
 		</>
-	) : (
-		<styled.Initials color={mainColor || getUserColor(initials)} size={imageSize} rounded={rounded}>
-			{initialsData}
-		</styled.Initials>
 	);
 };
 

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -63,7 +63,7 @@ Avatar.propTypes = {
 	firstname: PropTypes.string,
 	/** Apellido del usuario */
 	lastname: PropTypes.string,
-	/** Color del fondo para el Avatar de texto */
+	/**  Color de fondo de avatar. Aplica solo cuando se muestran las iniciales de nombre y apellido */
 	mainColor: PropTypes.string,
 	/** Medida de alto y ancho para la imagen en pixeles */
 	size: PropTypes.oneOfType([

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import useDevices from 'hooks/useDevices';
 import { getImageMeasurements } from 'theme/utils';
@@ -21,12 +21,25 @@ const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 		imageSize && `&s=${imageSize}`
 	}`;
 
-	const getInitials = () => (initials ? setInitialsData(initials) : setImage(defaultUserImage));
+	const getInitials = () => {
+		try {
+			const initials = getInitialsTheme(firstname, lastname, mainColor);
+
+			if (initials) setInitialsData(initials);
+			else setImage(defaultUserImage);
+		} catch {
+			setImage(defaultUserImage);
+		}
+	};
+
+	useEffect(() => {
+		if (url) setImage(url);
+	}, [url]);
 
 	return !initialsData ? (
 		<>
 			<styled.Image
-				src={url || image}
+				src={image}
 				alt={`${firstname} ${lastname}`}
 				onError={getInitials}
 				onLoad={() => setLoading(false)}

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -63,7 +63,7 @@ Avatar.propTypes = {
 	firstname: PropTypes.string,
 	/** Apellido del usuario */
 	lastname: PropTypes.string,
-	/**  Color de fondo de avatar. Aplica solo cuando se muestran las iniciales de nombre y apellido */
+	/** Color de fondo de avatar. Aplica solo cuando se muestran las iniciales de nombre y apellido */
 	mainColor: PropTypes.string,
 	/** Medida de alto y ancho para la imagen en pixeles */
 	size: PropTypes.oneOfType([

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { validColors } from 'components/Button/utils';
+import viewsPalette from 'theme/palette';
 import Avatar from './Avatar';
 
 const control = {
 	type: 'select',
-	options: validColors.reduce((options, color) => {
-		options[color] = color;
+	options: Object.keys(viewsPalette).reduce((options, colorName) => {
+		options[colorName] = viewsPalette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -34,7 +34,7 @@ export const WithName = Template.bind({});
 
 WithURL.args = {
 	...baseArgs,
-	url: '	https://janiscommerce.atlassian.net/wiki/aa-avatar/6345ddf753df3c01231fe83f'
+	url: 'https://cdn.id.janis.in/client-images/5ec2d43b70cd6700077c3aa1/0cdc0141-1f76-465a-8a06-8512b289eb85.png'
 };
 
 Default.args = {

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { validColors } from 'components/Button/utils';
+import Avatar from './Avatar';
+
+const control = {
+	type: 'select',
+	options: validColors.reduce((options, color) => {
+		options[color] = color;
+		return options;
+	}, {})
+};
+
+export default {
+	title: 'Components/Avatar',
+	component: Avatar,
+	parameters: {
+		layout: 'centered'
+	},
+	argTypes: {
+		mainColor: { control }
+	}
+};
+
+const Template = (args) => <Avatar {...args} />;
+
+const baseArgs = {
+	size: 'extralarge',
+	rounded: true
+};
+
+export const WithURL = Template.bind({});
+export const Default = Template.bind({});
+export const WithName = Template.bind({});
+
+WithURL.args = {
+	...baseArgs,
+	url: 'https://avatars.githubusercontent.com/u/64233677?v=4'
+};
+
+Default.args = {
+	...baseArgs
+};
+
+WithName.args = {
+	...baseArgs,
+	firstname: 'Esteban',
+	lastname: 'Quito'
+};

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -17,7 +17,11 @@ export default {
 		layout: 'centered'
 	},
 	argTypes: {
-		mainColor: { control }
+		mainColor: { control },
+		size: {
+			type: 'select',
+			options: ['small', 'medium', 'large', 'extralarge', 'auto']
+		}
 	}
 };
 

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -25,7 +25,7 @@ const Template = (args) => <Avatar {...args} />;
 
 const baseArgs = {
 	rounded: true,
-	size: 'extralarge'
+	size: 'large'
 };
 
 export const WithURL = Template.bind({});
@@ -34,7 +34,7 @@ export const WithName = Template.bind({});
 
 WithURL.args = {
 	...baseArgs,
-	url: 'https://avatars.githubusercontent.com/u/64233677?v=4'
+	url: '	https://janiscommerce.atlassian.net/wiki/aa-avatar/6345ddf753df3c01231fe83f'
 };
 
 Default.args = {

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -24,8 +24,8 @@ export default {
 const Template = (args) => <Avatar {...args} />;
 
 const baseArgs = {
-	size: 'extralarge',
-	rounded: true
+	rounded: true,
+	size: 'extralarge'
 };
 
 export const WithURL = Template.bind({});

--- a/src/components/Avatar/components/InitialsAvatar/InitialsAvatar.js
+++ b/src/components/Avatar/components/InitialsAvatar/InitialsAvatar.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from './styles';
+import { getUserColor } from 'components/Avatar/utils';
+
+const InitialsAvatar = ({ initials, mainColor, imageSize, rounded }) => {
+	return (
+		<styled.Initials color={mainColor || getUserColor(initials)} size={imageSize} rounded={rounded}>
+			{initials}
+		</styled.Initials>
+	);
+};
+
+InitialsAvatar.propTypes = {
+	initials: PropTypes.shape({}),
+	mainColor: PropTypes.string,
+	imageSize: PropTypes.string,
+	rounded: PropTypes.bool
+};
+
+export default InitialsAvatar;

--- a/src/components/Avatar/components/InitialsAvatar/index.js
+++ b/src/components/Avatar/components/InitialsAvatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './InitialsAvatar';

--- a/src/components/Avatar/components/InitialsAvatar/styles.js
+++ b/src/components/Avatar/components/InitialsAvatar/styles.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import mixins from 'theme/mixins';
+import viewsPalette from 'theme/palette';
+
+export default {
+	Initials: styled.div`
+		width: ${({ size }) => size};
+		height: ${({ size }) => size};
+		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
+		font-weight: 500;
+		color: ${viewsPalette.white};
+		background-color: ${({ color }) => color};
+		text-transform: uppercase;
+		${mixins.flexCenter};
+	`
+};

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Avatar';

--- a/src/components/Avatar/styles.js
+++ b/src/components/Avatar/styles.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import viewsPalette from 'theme/palette';
+
+export default {
+	Initials: styled.div`
+		width: ${({ size }) => size};
+		height: ${({ size }) => size};
+		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		font-weight: 500;
+		color: ${viewsPalette.white};
+		background-color: ${({ color }) => color};
+		text-transform: uppercase;
+	`,
+	Image: styled.img`
+		width: ${({ size }) => size};
+		height: ${({ size }) => size};
+		display: flex;
+		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
+	`
+};

--- a/src/components/Avatar/styles.js
+++ b/src/components/Avatar/styles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import mixins from 'theme/mixins';
 import viewsPalette from 'theme/palette';
 
 export default {
@@ -6,13 +7,11 @@ export default {
 		width: ${({ size }) => size};
 		height: ${({ size }) => size};
 		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
-		display: flex;
-		justify-content: center;
-		align-items: center;
 		font-weight: 500;
 		color: ${viewsPalette.white};
 		background-color: ${({ color }) => color};
 		text-transform: uppercase;
+		${mixins.flexCenter};
 	`,
 	Image: styled.img`
 		width: ${({ size }) => size};

--- a/src/components/Avatar/styles.js
+++ b/src/components/Avatar/styles.js
@@ -17,7 +17,7 @@ export default {
 	Image: styled.img`
 		width: ${({ size }) => size};
 		height: ${({ size }) => size};
-		display: flex;
+		display: ${({ show }) => (show ? 'flex' : 'none')};
 		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
 	`
 };

--- a/src/components/Avatar/styles.js
+++ b/src/components/Avatar/styles.js
@@ -1,18 +1,6 @@
 import styled from 'styled-components';
-import mixins from 'theme/mixins';
-import viewsPalette from 'theme/palette';
 
 export default {
-	Initials: styled.div`
-		width: ${({ size }) => size};
-		height: ${({ size }) => size};
-		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
-		font-weight: 500;
-		color: ${viewsPalette.white};
-		background-color: ${({ color }) => color};
-		text-transform: uppercase;
-		${mixins.flexCenter};
-	`,
 	Image: styled.img`
 		width: ${({ size }) => size};
 		height: ${({ size }) => size};

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -1,0 +1,77 @@
+import viewsPalette from 'theme/palette';
+
+/**
+ * Checks if the name provided is single or compound and returns either the first two letters,
+ * or the initials of the two first names.
+ * @param {string} nameString
+ */
+const parseName = (nameString) => {
+	const names = nameString.split(' ');
+	return names.length > 1
+		? names.reduce((accum, name, idx) => {
+				if (idx <= 1) return [...accum, name.substring(0, 1)];
+				return accum;
+		  }, [])
+		: nameString.substring(0, 2).split('');
+};
+
+/**
+ * If both firstname and lastname are provided, returns an array with each of their initials.
+ * If only a firstname or a lastname is provided, parses them to return either
+ * their initials (if it's a compound name) or first two letters.
+ * @param {string} firstname
+ * @param {string} lastname
+ */
+
+const getNamesToParse = (firstname, lastname) =>
+	!!firstname || !!lastname ? parseName(firstname || lastname) : null;
+
+/**
+ * Assigns a color to the names or initials array provided.
+ * @param {array} name - Array containing the firstname and lastname strings
+ */
+export const getUserColor = (name) => {
+	const availableColors = [
+		'blue',
+		'bluePressed',
+		'blueDisabled',
+		'darkGreyPressed',
+		'fizzGreen',
+		'fizzGreenPressed',
+		'greenPressed',
+		'lightBluePressed',
+		'orange',
+		'orangePressed',
+		'red',
+		'redPressed',
+		'yellowPressed'
+	];
+
+	const availableIndexes = availableColors.length;
+
+	const charCodes = [...name].map((letter) => letter.charCodeAt(0));
+
+	const len = charCodes.length;
+
+	const a = (len % (availableIndexes - 1)) + 1;
+	const c = charCodes.reduce((current, next) => current + next) % availableIndexes;
+
+	let random = charCodes[0] % availableIndexes;
+	for (let i = 0; i < len; i++) random = (a * random + c) % availableIndexes;
+
+	const userColor = availableColors[random];
+
+	return viewsPalette[userColor];
+};
+
+/**
+ * If firstname or lastname (or both) are defined, will return an object with their initials and assigned color.
+ * If not, returns null.
+ * @param {string} firstname
+ * @param {string} lastname
+ * @param {string} mainColor
+ */
+export const getInitialsTheme = (firstname = '', lastname = '') => {
+	if (!!firstname && !!lastname) return [firstname.substring(0, 1), lastname.substring(0, 1)];
+	return getNamesToParse(firstname, lastname);
+};

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -31,8 +31,10 @@ const getNamesToParse = (firstname, lastname) =>
  * @param {array} name - Array containing the firstname and lastname strings
  */
 export const getUserColor = (name) => {
+	const excludedColors = ['lightGreyHover', 'lightGrey', 'white', 'transparentWhite'];
+
 	const availableColors = Object.keys(viewsPalette).filter(
-		(color) => color !== 'white' && color !== 'transparentWhite'
+		(color) => !excludedColors.includes(color)
 	);
 
 	const availableIndexes = availableColors.length;

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -31,7 +31,7 @@ const getNamesToParse = (firstname, lastname) =>
  * @param {array} name - Array containing the firstname and lastname strings
  */
 export const getUserColor = (name) => {
-	const availableColors = Object.keys(viewsPalette);
+	const availableColors = Object.keys(viewsPalette).filter((color) => color !== 'white');
 
 	const availableIndexes = availableColors.length;
 

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -39,13 +39,15 @@ export const getUserColor = (name) => {
 
 	const charCodes = [...name].map((letter) => letter.charCodeAt(0));
 
-	const len = charCodes.length;
+	const charCodesLength = charCodes.length;
 
-	const a = (len % (availableIndexes - 1)) + 1;
-	const c = charCodes.reduce((current, next) => current + next) % availableIndexes;
+	const rotationFactor = (charCodesLength % (availableIndexes - 1)) + 1;
+	const sumOfCharacterCodes =
+		charCodes.reduce((current, next) => current + next) % availableIndexes;
 
 	let random = charCodes[0] % availableIndexes;
-	for (let i = 0; i < len; i++) random = (a * random + c) % availableIndexes;
+	for (let i = 0; i < charCodesLength; i++)
+		random = (rotationFactor * random + sumOfCharacterCodes) % availableIndexes;
 
 	const userColor = availableColors[random];
 

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -31,7 +31,9 @@ const getNamesToParse = (firstname, lastname) =>
  * @param {array} name - Array containing the firstname and lastname strings
  */
 export const getUserColor = (name) => {
-	const availableColors = Object.keys(viewsPalette).filter((color) => color !== 'white');
+	const availableColors = Object.keys(viewsPalette).filter(
+		(color) => color !== 'white' && color !== 'transparentWhite'
+	);
 
 	const availableIndexes = availableColors.length;
 

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -31,21 +31,7 @@ const getNamesToParse = (firstname, lastname) =>
  * @param {array} name - Array containing the firstname and lastname strings
  */
 export const getUserColor = (name) => {
-	const availableColors = [
-		'blue',
-		'bluePressed',
-		'blueDisabled',
-		'darkGreyPressed',
-		'fizzGreen',
-		'fizzGreenPressed',
-		'greenPressed',
-		'lightBluePressed',
-		'orange',
-		'orangePressed',
-		'red',
-		'redPressed',
-		'yellowPressed'
-	];
+	const availableColors = Object.keys(viewsPalette);
 
 	const availableIndexes = availableColors.length;
 
@@ -69,7 +55,6 @@ export const getUserColor = (name) => {
  * If not, returns null.
  * @param {string} firstname
  * @param {string} lastname
- * @param {string} mainColor
  */
 export const getInitialsTheme = (firstname = '', lastname = '') => {
 	if (!!firstname && !!lastname) return [firstname.substring(0, 1), lastname.substring(0, 1)];

--- a/src/components/Skeleton/Skeleton.js
+++ b/src/components/Skeleton/Skeleton.js
@@ -2,21 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from './styles';
 
-const Skeleton = ({ circle, width, height }) => (
-	<styled.SkeletonContainer width={width} height={height} circle={circle} />
-);
+const Skeleton = ({ circle, width, height, count, backgroundColor }) => {
+	const currentWidth = !Number.isNaN(Number(width)) ? `${width}px` : width;
+	const currentHeight = !Number.isNaN(Number(height)) ? `${height}px` : height;
+
+	const skeletons = Array.from({ length: count }, (_, index) => (
+		<styled.SkeletonContainer
+			key={index}
+			width={currentWidth}
+			height={currentHeight}
+			circle={circle}
+			backgroundColor={backgroundColor}
+		/>
+	));
+
+	return <>{skeletons}</>;
+};
 
 Skeleton.propTypes = {
 	/** Si está en true, se redondea el Skeleton */
 	circle: PropTypes.bool,
-	/** Ancho del Skeleton - Es requerido */
-	width: PropTypes.string.isRequired,
+	/** Cantidad de veces que se mostrará el Skeleton por uso */
+	count: PropTypes.number,
 	/** Alto del Skeleton - Es requerido */
-	height: PropTypes.string.isRequired
+	height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	/** Ancho del Skeleton - Es requerido */
+	width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	/** Color de fondo del Skeleton */
+	backgroundColor: PropTypes.string
 };
 
 Skeleton.defaultProps = {
-	circle: false
+	circle: false,
+	count: 1
 };
 
 export default Skeleton;

--- a/src/components/Skeleton/Skeleton.js
+++ b/src/components/Skeleton/Skeleton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from './styles';
+
+const Skeleton = ({ circle, width, height }) => (
+	<styled.SkeletonContainer width={width} height={height} circle={circle} />
+);
+
+Skeleton.propTypes = {
+	/** Si está en true, se redondea el Skeleton */
+	circle: PropTypes.bool,
+	/** Ancho del Skeleton - Es requerido */
+	width: PropTypes.string.isRequired,
+	/** Alto del Skeleton - Es requerido */
+	height: PropTypes.string.isRequired
+};
+
+Skeleton.defaultProps = {
+	circle: false
+};
+
+export default Skeleton;

--- a/src/components/Skeleton/Skeleton.stories.js
+++ b/src/components/Skeleton/Skeleton.stories.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import Skeleton from './Skeleton';
+import viewsPalette from 'theme/palette';
+
+const control = {
+	type: 'select',
+	options: Object.keys(viewsPalette).reduce((options, colorName) => {
+		options[colorName] = viewsPalette[colorName];
+		return options;
+	}, {})
+};
 
 export default {
 	title: 'Components/Skeleton',
 	component: Skeleton,
 	parameters: {
 		layout: 'centered'
+	},
+	argTypes: {
+		backgroundColor: { control }
 	}
 };
 

--- a/src/components/Skeleton/Skeleton.stories.js
+++ b/src/components/Skeleton/Skeleton.stories.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+export default {
+	title: 'Components/Skeleton',
+	component: Skeleton,
+	parameters: {
+		layout: 'centered'
+	}
+};
+
+const Template = (args) => <Skeleton {...args} />;
+
+const baseArgs = {
+	width: '100px',
+	height: '100px'
+};
+
+export const Rounded = Template.bind({});
+export const Square = Template.bind({});
+
+Rounded.args = {
+	circle: true,
+	...baseArgs
+};
+
+Square.args = {
+	...baseArgs,
+	height: '20px'
+};

--- a/src/components/Skeleton/Skeleton.stories.js
+++ b/src/components/Skeleton/Skeleton.stories.js
@@ -9,7 +9,11 @@ export default {
 	}
 };
 
-const Template = (args) => <Skeleton {...args} />;
+const Template = (args) => (
+	<div style={{ display: 'flex', gap: '3px' }}>
+		<Skeleton {...args} />
+	</div>
+);
 
 const baseArgs = {
 	width: '100px',

--- a/src/components/Skeleton/index.js
+++ b/src/components/Skeleton/index.js
@@ -1,0 +1,1 @@
+export { default } from './Skeleton';

--- a/src/components/Skeleton/styles.js
+++ b/src/components/Skeleton/styles.js
@@ -6,7 +6,7 @@ export default {
 		border-radius: ${({ circle }) => (circle ? ' 50%' : '3px')};
 		height: ${({ height }) => height};
 		width: ${({ width }) => width};
-		background-color: ${viewsPalette.lightGrey};
+		background-color: ${({ backgroundColor }) => backgroundColor || viewsPalette.lightGrey};
 		animation: pulse 1.5s ease-in-out infinite;
 
 		@keyframes pulse {

--- a/src/components/Skeleton/styles.js
+++ b/src/components/Skeleton/styles.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import viewsPalette from 'theme/palette';
+
+export default {
+	SkeletonContainer: styled.div`
+		border-radius: ${({ circle }) => (circle ? ' 50%' : '3px')};
+		height: ${({ height }) => height};
+		width: ${({ width }) => width};
+		background-color: ${viewsPalette.lightGrey};
+		animation: pulse 1.5s ease-in-out infinite;
+
+		@keyframes pulse {
+			0% {
+				opacity: 0.4;
+			}
+			50% {
+				opacity: 0.8;
+			}
+			100% {
+				opacity: 0.4;
+			}
+		}
+	`
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -15,6 +15,7 @@ import ErrorBoundary from './ErrorBoundary';
 import Link from './Link';
 import Drawer from './Drawer';
 import ClickAwayListener from './ClickAwayListener';
+import Skeleton from './Skeleton';
 
 export {
 	ErrorBoundary,
@@ -32,6 +33,7 @@ export {
 	Input,
 	Link,
 	QRCode,
+	Skeleton,
 	Switch,
 	Textarea
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+import Avatar from './Avatar';
 import Button from './Button';
 import Checkbox from './Checkbox';
 import Chip from './Chip';
@@ -17,19 +18,20 @@ import ClickAwayListener from './ClickAwayListener';
 
 export {
 	ErrorBoundary,
+	Avatar,
 	Button,
 	Checkbox,
 	Chip,
+	ClickAwayListener,
 	Color,
+	ColorPicker,
+	Drawer,
+	HTML,
 	Icon,
-	Switch,
-	Input,
-	Textarea,
 	Image,
+	Input,
 	Link,
 	QRCode,
-	ColorPicker,
-	HTML,
-	Drawer,
-	ClickAwayListener
+	Switch,
+	Textarea
 };

--- a/src/theme/utils.js
+++ b/src/theme/utils.js
@@ -17,4 +17,26 @@ const timingFunctions = {
 	accelerate: 'cubic-bezier(0.4, 0.0, 1, 1)'
 };
 
-export { getColor, timingFunctions };
+/**
+ * @name getImageMeasurements
+ * @description return color from palette
+ * @param {string} size
+ * @param {boolean} isDesktop
+ * @returns {string}
+ * @example getImageMeasurements('large', true) // '36px'
+ */
+const getImageMeasurements = (size, isDesktop) => {
+	if (!Number.isNaN(Number(size))) return `${size}px`;
+
+	const imageSizes = {
+		small: '24px',
+		medium: '32px',
+		large: '36px',
+		extralarge: isDesktop ? '140px' : '100px',
+		auto: 'auto'
+	};
+
+	return imageSizes[size] || imageSizes.small;
+};
+
+export { getColor, getImageMeasurements, timingFunctions };


### PR DESCRIPTION
**Link al ticket**
https://janiscommerce.atlassian.net/browse/JMV-3314

**Descripción del requerimiento**
Se necesita contar con un componente Avatar, que se utilice para mostrar una imagen para el usuario

**Descripción de la solución**

- Se creó un componente `Avatar` en `src/components`, el mismo se pensó agnóstico ya que recibiendo ciertas props, se muestra desde cualquier lugar donde se lo importe
- Además, al necesitar esperar para la carga de la imagen, se creó el componente Skeleton, que mediante una animación muestra un skeleton simulando la carga de data - Esto se encontraba en un [evolutivo de ui-web](https://janiscommerce.atlassian.net/browse/JMV-3273), donde analizamos crear un Skeleton sin librerías, que se volverá a analizar para que se implemente en distintos componentes y se avanzará la creación del skeleton en esta
- A tener en cuenta, para el `Skeleton` se tuvo en cuenta todas las posibilidades que se utilizan hoy, desde views le aplicamos `height`, `width` y `count`, con el count lo que hacemos es mostrar el mismo componente varias veces (se puede probar de storybook) la alineación queda en dependencia del padre del Skeleton, si le agregamos count sin estilos al padre se alinearan pegados uno bajo el otro, el problema radica en que ademas, en Views en algunos casos estamos usando un `SkeletonTheme`, estos casos los dejaría con la dependencia `react-loading-skeleton` y lo abordaría en otra tarea ya que requiere mas investigación, los `Skeleton` que no utilizan `SkeletonTheme` ya pueden cambiarse
- En ciertos casos encontré que le estamos pasando al `Skeleton` la prop `highlightColor`, sin embargo no es una prop del `Skeleton` sino del `SkeletonTheme`, por lo que no se debería utilizar mas
![image](https://github.com/janis-commerce/ui-web/assets/64233677/dd38cef0-c0f8-47a4-b45a-9d140af6fab5)

**¿Cómo se puede probar?**
Levantando Ui-web en la rama actual, 

**Para probarlo en Storybook**
- Correr el comando yarn storybook
- Ingresando a ver el [Skeleton](http://localhost:6006/?path=/story/components-skeleton--rounded) o el [Avatar](http://localhost:6006/?path=/docs/components-avatar--with-url)

**Para probarlo en Views**
- Iniciando el proyecto UI-WEB en la rama actual
- Borrar `node_modules` en caso de tenerlos
- Correr comando `yarn`
- Luego correr comando `yarn build`
- Y para finalizar correr el comando `yalc publish`

Luego ingresamos a Views yo deje una rama con los cambios iniciales solo para ver el Avatar y el Skeleton, en esa rama por el momento solamente se cambio el componente estilizado que mostraba el UserImage por el Avatar proveniente de ui-web y el skeleton de la lista de clientes

- Ingresar a `JMV-3340-utilizar-el-avatar-en-views`
- Bajar el docker
- Borrar node_modules en caso de tenerlos
- Correr el comando yalc add @janiscommerce/ui-web
- Correr comando npm i
- Levantar el docker 

**Pantallas a revisar**
[Browse de claim](http://janis.localhost:3001/csx/claim/browse) => En este browse se ven varios avatar sin imagen ni nombre
[Devops user browse](http://janis.localhost:3001/devops/user/browse) => Varios avatar con imagen y nombre
[Full-user browse](http://janis.localhost:3001/id/full-user/browse) => muestra algunos en default, con imagen y con iniciales
[User browse](http://janis.localhost:3001/id/user/browse)

Para probar el Skeleton, hice un cambio en Views en la rama de prueba que menciono arriba, aún asi debemos hacer un cambio para verlo
- Ingresar a views en el archivo `src/components/ClientsModal/ClientsModal.js`
- En el mismo, en la linea 235, valida si es loading muestra un `ClientSkeletonItem`, cambiar la validacion que sea `!isLoading` para que quede cargando
- En el archivo `ClientSkeletonItem` dejo aplicado el Skeleton de Ui-Web
- Esto debería dejar la lista de clientes con el skeleton cargando lo que se veria asi:
![image](https://github.com/janis-commerce/ui-web/assets/64233677/bb700cf8-fe81-4060-b876-a440f311c097)
Otro caso en el que se puede probar es cambiando en `src/components/Navbar/SearchModal/components/SearchResult/SearchResult.js` el Skeleton de la libreria por el de `@janiscommerce/ui-web` y deberia funcionar igual en el buscador de la Navbar
![image](https://github.com/janis-commerce/ui-web/assets/64233677/37816909-bd75-41f9-a78a-95b5d9b53b4f)
![image](https://github.com/janis-commerce/ui-web/assets/64233677/faea6e82-0a40-439e-8ba9-4245bacbce0d)

_UserImage debería verse asi_
![image](https://github.com/janis-commerce/ui-web/assets/64233677/439d0463-a800-43bd-8337-599b9d3b2482)


**Screenshot**
Avatar de menu
![image](https://github.com/janis-commerce/ui-web/assets/64233677/51ff15cd-1d08-4e65-b0c1-63dd52ff1be4)

en el [browse de id](http://janis.localhost:3001/id/user/browse)
![image](https://github.com/janis-commerce/ui-web/assets/64233677/28ff8b0e-6eff-41a8-a77a-6ee56eec93f8)

durante la carga
![image](https://github.com/janis-commerce/ui-web/assets/64233677/fdbaa0fb-7079-4c51-8082-39306d71d199)

Storybook Avatar
![image](https://github.com/janis-commerce/ui-web/assets/64233677/55dfd141-0752-4aa3-8373-7140fcbc9d3e)

Skeleton
![image](https://github.com/janis-commerce/ui-web/assets/64233677/3e061858-af1f-43ad-83c3-c43d736db8d8)

