### PR TITLE
available colors

### DIFF
--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,11 +1,12 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useDevices from 'hooks/useDevices';
+import viewsPalette from 'theme/palette';
 import { getImageMeasurements } from 'theme/utils';
 import Skeleton from 'components/Skeleton';
 import styled from './styles';
-import { getInitialsTheme } from './utils';
 import InitialsAvatar from './components/InitialsAvatar';
+import { getInitialsTheme } from './utils';
 
 const Avatar = ({ firstname, lastname, mainColor, size, url, rounded }) => {
 	const imageRef = useRef();
@@ -81,7 +82,8 @@ Avatar.defaultProps = {
 	lastname: '',
 	size: 'small',
 	url: '',
-	rounded: true
+	rounded: true,
+	mainColor: viewsPalette.grey
 };
 
 export default Avatar;

--- a/src/components/Avatar/components/InitialsAvatar/InitialsAvatar.js
+++ b/src/components/Avatar/components/InitialsAvatar/InitialsAvatar.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from './styles';
-import { getUserColor } from 'components/Avatar/utils';
 
 const InitialsAvatar = ({ initials, mainColor, imageSize, rounded }) => {
 	return (
-		<styled.Initials color={mainColor || getUserColor(initials)} size={imageSize} rounded={rounded}>
+		<styled.Initials color={mainColor} size={imageSize} rounded={rounded}>
 			{initials}
 		</styled.Initials>
 	);

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -1,21 +1,3 @@
-import viewsPalette from 'theme/palette';
-
-const availableColors = [
-	'blue',
-	'bluePressed',
-	'blueDisabled',
-	'darkGreyPressed',
-	'fizzGreen',
-	'fizzGreenPressed',
-	'greenPressed',
-	'lightBluePressed',
-	'orange',
-	'orangePressed',
-	'red',
-	'redPressed',
-	'yellowPressed'
-];
-
 /**
  * Checks if the name provided is single or compound and returns either the first two letters,
  * or the initials of the two first names.
@@ -41,34 +23,6 @@ const parseName = (nameString) => {
 
 const getNamesToParse = (firstname, lastname) =>
 	!!firstname || !!lastname ? parseName(firstname || lastname) : null;
-
-/**
- * Assigns a color to the names or initials array provided.
- * @param {array} name - Array containing the firstname and lastname strings
- */
-export const getUserColor = (name) => {
-	const currentColors = Object.keys(viewsPalette).filter((color) =>
-		availableColors.includes(color)
-	);
-
-	const availableIndexes = currentColors.length;
-
-	const charCodes = [...name].map((letter) => letter.charCodeAt(0));
-
-	const charCodesLength = charCodes.length;
-
-	const rotationFactor = (charCodesLength % (availableIndexes - 1)) + 1;
-	const sumOfCharacterCodes =
-		charCodes.reduce((current, next) => current + next) % availableIndexes;
-
-	let random = charCodes[0] % availableIndexes;
-	for (let i = 0; i < charCodesLength; i++)
-		random = (rotationFactor * random + sumOfCharacterCodes) % availableIndexes;
-
-	const userColor = currentColors[random];
-
-	return viewsPalette[userColor];
-};
 
 /**
  * If firstname or lastname (or both) are defined, will return an object with their initials and assigned color.

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -1,5 +1,21 @@
 import viewsPalette from 'theme/palette';
 
+const availableColors = [
+	'blue',
+	'bluePressed',
+	'blueDisabled',
+	'darkGreyPressed',
+	'fizzGreen',
+	'fizzGreenPressed',
+	'greenPressed',
+	'lightBluePressed',
+	'orange',
+	'orangePressed',
+	'red',
+	'redPressed',
+	'yellowPressed'
+];
+
 /**
  * Checks if the name provided is single or compound and returns either the first two letters,
  * or the initials of the two first names.
@@ -31,13 +47,11 @@ const getNamesToParse = (firstname, lastname) =>
  * @param {array} name - Array containing the firstname and lastname strings
  */
 export const getUserColor = (name) => {
-	const excludedColors = ['lightGreyHover', 'lightGrey', 'white', 'transparentWhite'];
-
-	const availableColors = Object.keys(viewsPalette).filter(
-		(color) => !excludedColors.includes(color)
+	const currentColors = Object.keys(viewsPalette).filter((color) =>
+		availableColors.includes(color)
 	);
 
-	const availableIndexes = availableColors.length;
+	const availableIndexes = currentColors.length;
 
 	const charCodes = [...name].map((letter) => letter.charCodeAt(0));
 
@@ -51,7 +65,7 @@ export const getUserColor = (name) => {
 	for (let i = 0; i < charCodesLength; i++)
 		random = (rotationFactor * random + sumOfCharacterCodes) % availableIndexes;
 
-	const userColor = availableColors[random];
+	const userColor = currentColors[random];
 
 	return viewsPalette[userColor];
 };

--- a/src/components/Skeleton/Skeleton.js
+++ b/src/components/Skeleton/Skeleton.js
@@ -34,7 +34,8 @@ Skeleton.propTypes = {
 
 Skeleton.defaultProps = {
 	circle: false,
-	count: 1
+	count: 1,
+	width: '100%'
 };
 
 export default Skeleton;


### PR DESCRIPTION
**Link al ticket**
https://janiscommerce.atlassian.net/browse/JMV-3314

**Descripción del requerimiento**
Se necesita que se vuelva a usar la lista de colores disponibles que habia en UserImage ya que contrastan con el fondo algunos casos
![image](https://github.com/janis-commerce/ui-web/assets/64233677/7e38f193-b837-4603-b4fd-0c24314017da)
Al recibir este comentario me di cuenta que había borrado la lista de colores disponibles del utils

**Descripción de la solución**
Se cambió la idea de sortear un color en el componente Avatar a que eso sea responsabilidad de quien usa el componente, el Avatar recibe solo un mainColor para mostrar en caso de mostrar el Avatar de iniciales y posee un defafult gris
Se aprovecho para darle un width por default al `Skeleton`

**¿Cómo se puede probar?**
Levantando Ui-web en la rama actual, 

**Para probarlo en Views**
- Iniciando el proyecto UI-WEB en la rama actual
- Borrar `node_modules` en caso de tenerlos
- Correr comando `yarn`
- Luego correr comando `yarn build`
- Y para finalizar correr el comando `yalc publish`

Luego ingresamos a Views puede hacerse sobre beta, sino 
- Ingresar a `JMV-3340-utilizar-el-avatar-en-views`
- Bajar el docker
- Borrar node_modules en caso de tenerlos
- Correr el comando yalc add @janiscommerce/ui-web
- Correr comando npm i
- Levantar el docker 

De esta manera todos los Avatar que no reciban color van a ser grises, desde Views debemos enviarle la función que crea un color al azar

**Screenshot**
asi lo veia 
![image](https://github.com/janis-commerce/ui-web/assets/64233677/094d1212-276f-4b6b-9289-efb855fff4e6)

asi lo veo ahora con el cambio
![image](https://github.com/janis-commerce/ui-web/assets/64233677/8043c538-baa4-4cc5-a157-059886fadbe7)

