### PR TITLE
Jmv 3349 create uiweb avatargroup

### DIFF
--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -3,37 +3,23 @@ import PropTypes from 'prop-types';
 import Avatar from 'components/Avatar';
 import viewsPalette from 'theme/palette';
 import styled from './styles';
+import AvatarList from './components/AvatarList';
 
 const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false }) => {
-	const extraCount = users.length > usersToDisplay ? users.length - usersToDisplay : 0;
+	const extraCount = users.length > usersToDisplay + 1 ? users.length - (usersToDisplay + 1) : 0;
 	const extraCountActualIndex = extraCount + 1;
 	const hasExtraCount = extraCount > 0;
 
-	const renderAvatars = (userList) =>
-		userList.map(({ firstname, lastname, url, id }, index) => {
-			if (hasExtraCount && index < extraCountActualIndex) return null;
-			return (
-				<Avatar
-					key={id}
-					firstname={firstname}
-					lastname={lastname}
-					url={url}
-					size={showFull ? 'large' : 'small'}
-				/>
-			);
-		});
-
 	return (
 		<styled.AvatarGroup disabled showFull={showFull}>
-			{renderAvatars(users)}
+			<AvatarList
+				userList={users}
+				hasExtraCount={hasExtraCount}
+				extraCountActualIndex={extraCountActualIndex}
+				showFull={showFull}
+			/>
 			{hasExtraCount && (
-				<styled.ExtraButton>
-					<Avatar
-						firstname="+"
-						lastname={`${extraCountActualIndex}`}
-						mainColor={viewsPalette.blue}
-					/>
-				</styled.ExtraButton>
+				<Avatar firstname="+" lastname={`${extraCountActualIndex}`} mainColor={viewsPalette.blue} />
 			)}
 		</styled.AvatarGroup>
 	);

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Avatar from 'components/Avatar';
+import viewsPalette from 'theme/palette';
+import styled from './styles';
+
+const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false }) => {
+	const extraCount = users.length > usersToDisplay ? users.length - usersToDisplay : 0;
+	const extraCountActualIndex = extraCount + 1;
+	const hasExtraCount = extraCount > 0;
+
+	const renderAvatars = (userList) =>
+		userList.map(({ firstname, lastname, url, id }, index) => {
+			if (hasExtraCount && index < extraCountActualIndex) return null;
+			return (
+				<Avatar
+					key={id}
+					firstname={firstname}
+					lastname={lastname}
+					url={url}
+					size={showFull ? 'large' : 'small'}
+				/>
+			);
+		});
+
+	return (
+		<styled.AvatarGroup disabled showFull={showFull}>
+			{renderAvatars(users)}
+			{hasExtraCount && (
+				<styled.ExtraButton>
+					<Avatar
+						firstname="+"
+						lastname={`${extraCountActualIndex}`}
+						mainColor={viewsPalette.blue}
+					/>
+				</styled.ExtraButton>
+			)}
+		</styled.AvatarGroup>
+	);
+};
+
+AvatarGroup.propTypes = {
+	users: PropTypes.arrayOf(PropTypes.object),
+	usersToDisplay: PropTypes.number,
+	showFull: PropTypes.bool
+};
+
+export default React.memo(AvatarGroup);

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -5,7 +5,7 @@ import viewsPalette from 'theme/palette';
 import styled from './styles';
 import AvatarList from './components/AvatarList';
 
-const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false }) => {
+const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false, badgeColor }) => {
 	const extraCount = users.length > usersToDisplay + 1 ? users.length - (usersToDisplay + 1) : 0;
 	const extraCountActualIndex = extraCount + 1;
 	const hasExtraCount = extraCount > 0;
@@ -19,16 +19,25 @@ const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false }) => {
 				showFull={showFull}
 			/>
 			{hasExtraCount && (
-				<Avatar firstname="+" lastname={`${extraCountActualIndex}`} mainColor={viewsPalette.blue} />
+				<Avatar firstname="+" lastname={`${extraCountActualIndex}`} mainColor={badgeColor} />
 			)}
 		</styled.AvatarGroup>
 	);
 };
 
 AvatarGroup.propTypes = {
+	/** Data de usuarios para los avatar */
 	users: PropTypes.arrayOf(PropTypes.object),
+	/** Cantidad de usuarios que se verá el Avatar */
 	usersToDisplay: PropTypes.number,
-	showFull: PropTypes.bool
+	/** Muestra la lista de Avatars en tamaño completo */
+	showFull: PropTypes.bool,
+	/** Color del fondo del Avatar en caso de mostrar mas */
+	badgeColor: PropTypes.string
+};
+
+AvatarGroup.defaultProps = {
+	badgeColor: viewsPalette.blue
 };
 
 export default React.memo(AvatarGroup);

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -6,8 +6,7 @@ import styled from './styles';
 import AvatarList from './components/AvatarList';
 
 const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false, badgeColor }) => {
-	const extraCount = users.length > usersToDisplay + 1 ? users.length - (usersToDisplay + 1) : 0;
-	const extraCountActualIndex = extraCount + 1;
+	const extraCount = users.length > usersToDisplay ? users.length - usersToDisplay : 0;
 	const hasExtraCount = extraCount > 0;
 
 	return (
@@ -15,12 +14,10 @@ const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false, badgeCo
 			<AvatarList
 				userList={users}
 				hasExtraCount={hasExtraCount}
-				extraCountActualIndex={extraCountActualIndex}
+				extraCount={extraCount}
 				showFull={showFull}
 			/>
-			{hasExtraCount && (
-				<Avatar firstname="+" lastname={`${extraCountActualIndex}`} mainColor={badgeColor} />
-			)}
+			{hasExtraCount && <Avatar firstname="+" lastname={`${extraCount}`} mainColor={badgeColor} />}
 		</styled.AvatarGroup>
 	);
 };

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -5,18 +5,13 @@ import viewsPalette from 'theme/palette';
 import styled from './styles';
 import AvatarList from './components/AvatarList';
 
-const AvatarGroup = ({ users = [], usersToDisplay = 5, showFull = false, badgeColor }) => {
+const AvatarGroup = ({ users = [], usersToDisplay = 5, badgeColor }) => {
 	const extraCount = users.length > usersToDisplay ? users.length - usersToDisplay : 0;
 	const hasExtraCount = extraCount > 0;
 
 	return (
-		<styled.AvatarGroup disabled showFull={showFull}>
-			<AvatarList
-				userList={users}
-				hasExtraCount={hasExtraCount}
-				extraCount={extraCount}
-				showFull={showFull}
-			/>
+		<styled.AvatarGroup disabled>
+			<AvatarList userList={users} hasExtraCount={hasExtraCount} extraCount={extraCount} />
 			{hasExtraCount && <Avatar firstname="+" lastname={`${extraCount}`} mainColor={badgeColor} />}
 		</styled.AvatarGroup>
 	);
@@ -27,8 +22,6 @@ AvatarGroup.propTypes = {
 	users: PropTypes.arrayOf(PropTypes.object),
 	/** Cantidad de usuarios que se verá el Avatar */
 	usersToDisplay: PropTypes.number,
-	/** Muestra la lista de Avatars en tamaño completo */
-	showFull: PropTypes.bool,
 	/** Color del fondo del Avatar en caso de mostrar mas */
 	badgeColor: PropTypes.string
 };

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -5,13 +5,18 @@ import viewsPalette from 'theme/palette';
 import styled from './styles';
 import AvatarList from './components/AvatarList';
 
-const AvatarGroup = ({ users = [], usersToDisplay = 5, badgeColor }) => {
+const AvatarGroup = ({ users, usersToDisplay, showFull, badgeColor }) => {
 	const extraCount = users.length > usersToDisplay ? users.length - usersToDisplay : 0;
 	const hasExtraCount = extraCount > 0;
 
 	return (
-		<styled.AvatarGroup disabled>
-			<AvatarList userList={users} hasExtraCount={hasExtraCount} extraCount={extraCount} />
+		<styled.AvatarGroup disabled showFull={showFull}>
+			<AvatarList
+				userList={users}
+				hasExtraCount={hasExtraCount}
+				extraCount={extraCount}
+				showFull={showFull}
+			/>
 			{hasExtraCount && <Avatar firstname="+" lastname={`${extraCount}`} mainColor={badgeColor} />}
 		</styled.AvatarGroup>
 	);
@@ -22,12 +27,17 @@ AvatarGroup.propTypes = {
 	users: PropTypes.arrayOf(PropTypes.object),
 	/** Cantidad de usuarios que se verá el Avatar */
 	usersToDisplay: PropTypes.number,
+	/** Muestra la lista de Avatars en tamaño completo */
+	showFull: PropTypes.bool,
 	/** Color del fondo del Avatar en caso de mostrar mas */
 	badgeColor: PropTypes.string
 };
 
 AvatarGroup.defaultProps = {
-	badgeColor: viewsPalette.blue
+	badgeColor: viewsPalette.blue,
+	users: [],
+	usersToDisplay: 5,
+	showFull: false
 };
 
 export default React.memo(AvatarGroup);

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -17,7 +17,14 @@ const AvatarGroup = ({ users, usersToDisplay, showFull, badgeColor }) => {
 				extraCount={extraCount}
 				showFull={showFull}
 			/>
-			{hasExtraCount && <Avatar firstname="+" lastname={`${extraCount}`} mainColor={badgeColor} />}
+			{hasExtraCount && (
+				<Avatar
+					firstname="+"
+					lastname={`${extraCount}`}
+					mainColor={badgeColor}
+					size={showFull ? 'large' : 'small'}
+				/>
+			)}
 		</styled.AvatarGroup>
 	);
 };

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -30,7 +30,7 @@ const baseArgs = {
 
 export const WithTwoAvatars = Template.bind({});
 export const WithFourAvatars = Template.bind({});
-export const ShowFull = Template.bind({});
+export const WithSixAvatars = Template.bind({});
 
 WithTwoAvatars.args = {
 	...baseArgs,
@@ -42,7 +42,7 @@ WithFourAvatars.args = {
 	usersToDisplay: 4
 };
 
-ShowFull.args = {
+WithSixAvatars.args = {
 	...baseArgs,
-	showFull: true
+	usersToDisplay: 6
 };

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -30,7 +30,7 @@ const baseArgs = {
 
 export const WithTwoAvatars = Template.bind({});
 export const WithFourAvatars = Template.bind({});
-export const WithSixAvatars = Template.bind({});
+export const ShowFull = Template.bind({});
 
 WithTwoAvatars.args = {
 	...baseArgs,
@@ -42,7 +42,7 @@ WithFourAvatars.args = {
 	usersToDisplay: 4
 };
 
-WithSixAvatars.args = {
+ShowFull.args = {
 	...baseArgs,
-	usersToDisplay: 6
+	showFull: true
 };

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -45,7 +45,7 @@ WithFourAvatars.args = {
 
 WithSixAvatars.args = {
 	...baseArgs,
-	usersToDisplay: 4,
+	usersToDisplay: 6,
 	showFull: true
 };
 

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -30,6 +30,7 @@ const baseArgs = {
 
 export const WithTwoAvatars = Template.bind({});
 export const WithFourAvatars = Template.bind({});
+export const WithSixAvatars = Template.bind({});
 export const ShowFull = Template.bind({});
 
 WithTwoAvatars.args = {
@@ -42,7 +43,14 @@ WithFourAvatars.args = {
 	usersToDisplay: 4
 };
 
+WithSixAvatars.args = {
+	...baseArgs,
+	usersToDisplay: 4,
+	showFull: true
+};
+
 ShowFull.args = {
 	...baseArgs,
-	showFull: true
+	showFull: true,
+	usersToDisplay: 10
 };

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import AvatarGroup from './AvatarGroup';
+import users from './usersMock.json';
+
+export default {
+	title: 'Components/AvatarGroup',
+	component: AvatarGroup,
+	parameters: {
+		layout: 'centered'
+	}
+};
+
+const Template = (args) => <AvatarGroup {...args} />;
+
+const baseArgs = {
+	users
+};
+
+export const WithTwoAvatars = Template.bind({});
+export const WithFourAvatars = Template.bind({});
+export const ShowFull = Template.bind({});
+
+WithTwoAvatars.args = {
+	...baseArgs,
+	usersToDisplay: 2
+};
+
+WithFourAvatars.args = {
+	...baseArgs,
+	usersToDisplay: 4
+};
+
+ShowFull.args = {
+	...baseArgs,
+	showFull: true
+};

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -1,12 +1,24 @@
 import React from 'react';
 import AvatarGroup from './AvatarGroup';
 import users from './usersMock.json';
+import viewsPalette from 'theme/palette';
+
+const control = {
+	type: 'select',
+	options: Object.keys(viewsPalette).reduce((options, colorName) => {
+		options[colorName] = viewsPalette[colorName];
+		return options;
+	}, {})
+};
 
 export default {
 	title: 'Components/AvatarGroup',
 	component: AvatarGroup,
 	parameters: {
 		layout: 'centered'
+	},
+	argTypes: {
+		badgeColor: { control }
 	}
 };
 

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Avatar from 'components/Avatar';
 
-const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }) => {
-	return userList.map(({ firstname, lastname, url, id, mainColor }, index) => {
-		if (hasExtraCount && index < extraCountActualIndex) return null;
+const AvatarList = ({ userList, hasExtraCount, extraCount, showFull }) =>
+	userList.map(({ firstname, lastname, url, id, mainColor }, index) => {
+		if (hasExtraCount && index < extraCount) return null;
 		return (
 			<Avatar
 				key={id}
@@ -15,6 +15,5 @@ const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }
 			/>
 		);
 	});
-};
 
 export default AvatarList;

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import Avatar from 'components/Avatar';
 
-const AvatarList = ({ userList, hasExtraCount, extraCount }) =>
+const AvatarList = ({ userList, hasExtraCount, extraCount, showFull }) =>
 	userList.map(({ firstname, lastname, url, id, mainColor }, index) => {
 		if (hasExtraCount && index < extraCount) return null;
 		return (
-			<Avatar key={id} firstname={firstname} lastname={lastname} url={url} mainColor={mainColor} />
+			<Avatar
+				key={id}
+				firstname={firstname}
+				lastname={lastname}
+				url={url}
+				size={showFull ? 'large' : 'small'}
+				mainColor={mainColor}
+			/>
 		);
 	});
 

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -1,18 +1,11 @@
 import React from 'react';
 import Avatar from 'components/Avatar';
 
-const AvatarList = ({ userList, hasExtraCount, extraCount, showFull }) =>
+const AvatarList = ({ userList, hasExtraCount, extraCount }) =>
 	userList.map(({ firstname, lastname, url, id, mainColor }, index) => {
 		if (hasExtraCount && index < extraCount) return null;
 		return (
-			<Avatar
-				key={id}
-				firstname={firstname}
-				lastname={lastname}
-				url={url}
-				size={showFull ? 'large' : 'small'}
-				mainColor={mainColor}
-			/>
+			<Avatar key={id} firstname={firstname} lastname={lastname} url={url} mainColor={mainColor} />
 		);
 	});
 

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Avatar from 'components/Avatar';
 
 const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }) => {
-	return userList.map(({ firstname, lastname, url, id }, index) => {
+	return userList.map(({ firstname, lastname, url, id, mainColor }, index) => {
 		if (hasExtraCount && index < extraCountActualIndex) return null;
 		return (
 			<Avatar
@@ -11,6 +11,7 @@ const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }
 				lastname={lastname}
 				url={url}
 				size={showFull ? 'large' : 'small'}
+				mainColor={mainColor}
 			/>
 		);
 	});

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -1,0 +1,19 @@
+import Avatar from 'components/Avatar';
+import React from 'react';
+
+const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }) => {
+	return userList.map(({ firstname, lastname, url, id }, index) => {
+		if (hasExtraCount && index < extraCountActualIndex) return null;
+		return (
+			<Avatar
+				key={id}
+				firstname={firstname}
+				lastname={lastname}
+				url={url}
+				size={showFull ? 'large' : 'small'}
+			/>
+		);
+	});
+};
+
+export default AvatarList;

--- a/src/components/AvatarGroup/components/AvatarList.js
+++ b/src/components/AvatarGroup/components/AvatarList.js
@@ -1,5 +1,5 @@
-import Avatar from 'components/Avatar';
 import React from 'react';
+import Avatar from 'components/Avatar';
 
 const AvatarList = ({ userList, hasExtraCount, extraCountActualIndex, showFull }) => {
 	return userList.map(({ firstname, lastname, url, id }, index) => {

--- a/src/components/AvatarGroup/components/index.js
+++ b/src/components/AvatarGroup/components/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvatarList';

--- a/src/components/AvatarGroup/index.js
+++ b/src/components/AvatarGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvatarGroup';

--- a/src/components/AvatarGroup/styles.js
+++ b/src/components/AvatarGroup/styles.js
@@ -47,10 +47,5 @@ export default {
 				margin-left: 0px;
 			}
 		}
-	`,
-	ExtraButton: styled.div`
-		&:active {
-			border-color: green;
-		}
 	`
 };

--- a/src/components/AvatarGroup/styles.js
+++ b/src/components/AvatarGroup/styles.js
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components';
+import Chip from 'components/Chip';
+import viewsPalette from 'theme/palette';
+
+export default {
+	AvatarGroup: styled(Chip)`
+		pointer-events: none;
+		${({ showFull, backgroundColor }) =>
+			showFull
+				? css`
+						height: 45px;
+						padding-left: 9px;
+						padding-right: 9px;
+						max-width: inherit;
+						&:hover,
+						&:active {
+							background: ${backgroundColor || viewsPalette.white};
+						}
+				  `
+				: css`
+						height: 33px;
+						padding-left: 5px;
+						padding-right: 5px;
+						cursor: pointer;
+				  `}
+		background: ${({ backgroundColor }) => backgroundColor || viewsPalette.white};
+		${({ inactive }) =>
+			inactive &&
+			`
+           &:hover {
+               background: ${viewsPalette.white};
+           }
+           &:active {
+               border-color: #EAEBED;
+           }
+    `}
+		& div {
+			display: flex;
+			& div,
+			img,
+			span {
+				&:not(:first-child) {
+					margin-left: -4px;
+				}
+			}
+			span:first-of-type {
+				margin-left: 0px;
+			}
+		}
+	`,
+	ExtraButton: styled.div`
+		&:active {
+			border-color: green;
+		}
+	`
+};

--- a/src/components/AvatarGroup/usersMock.json
+++ b/src/components/AvatarGroup/usersMock.json
@@ -16,7 +16,7 @@
 		"status": "active"
 	},
 	{
-		"id": "5dcda8a703d3922d3c1ae19e",
+		"id": "5dcda8a703d3922d3c1aeafae",
 		"email": "empty@janis.im",
 		"status": "active"
 	},

--- a/src/components/AvatarGroup/usersMock.json
+++ b/src/components/AvatarGroup/usersMock.json
@@ -23,6 +23,7 @@
 	{
 		"id": "5e7d127361152432f36e9c54",
 		"firstname": "Franco",
+		"lastname": "Fioravanti",
 		"mainColor": "green",
 		"email": "franco.fiora@janis.im",
 		"status": "active"

--- a/src/components/AvatarGroup/usersMock.json
+++ b/src/components/AvatarGroup/usersMock.json
@@ -1,6 +1,6 @@
 [
 	{
-		"id": "6336dcf381f2a0af54ab2d55",
+		"id": "1",
 		"firstname": "Damian",
 		"lastname": "Giannico",
 		"email": "damian.giannico@janis.im",
@@ -8,7 +8,7 @@
 		"status": "active"
 	},
 	{
-		"id": "5dcda8a703d3922d3c1ae19e",
+		"id": "2",
 		"firstname": "Francisco",
 		"lastname": "Zapata",
 		"email": "francisco.zapata@janis.im",
@@ -16,12 +16,12 @@
 		"status": "active"
 	},
 	{
-		"id": "5dcda8a703d3922d3c1aeafae",
+		"id": "3",
 		"email": "empty@janis.im",
 		"status": "active"
 	},
 	{
-		"id": "5e7d127361152432f36e9c54",
+		"id": "4",
 		"firstname": "Franco",
 		"lastname": "Fioravanti",
 		"mainColor": "green",
@@ -29,7 +29,7 @@
 		"status": "active"
 	},
 	{
-		"id": "5e7d192361152432f370f095",
+		"id": "5",
 		"firstname": "Fernando",
 		"lastname": "Colom",
 		"email": "fernando.colom@janis.im",
@@ -37,7 +37,7 @@
 		"status": "active"
 	},
 	{
-		"id": "60dc8d21d2db229ce2b077bc",
+		"id": "6",
 		"firstname": "Sebastian",
 		"lastname": "Vitielo",
 		"email": "sebastian.vitielo@janis.im",
@@ -45,7 +45,7 @@
 		"status": "active"
 	},
 	{
-		"id": "6336dcf381f2a0af54ab2d11",
+		"id": "7",
 		"firstname": "Mauro",
 		"lastname": "Arteaga",
 		"email": "mauro.arteaga@janis.im",

--- a/src/components/AvatarGroup/usersMock.json
+++ b/src/components/AvatarGroup/usersMock.json
@@ -1,0 +1,50 @@
+[
+	{
+		"id": "6336dcf381f2a0af54ab2d55",
+		"firstname": "Damian",
+		"lastname": "Giannico",
+		"email": "damian.giannico@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/631268b155b0a9e29f1b4026/5a3ee1ac-7da5-4a4c-a198-fa4c9fe7c3a6/48",
+		"status": "active"
+	},
+	{
+		"id": "5dcda8a703d3922d3c1ae19e",
+		"firstname": "Francisco",
+		"lastname": "Zapata",
+		"email": "francisco.zapata@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/63da4463c2b1cb6b3470270d/fcef0861-0f44-42a3-a00c-90b765b73c17/48",
+		"status": "active"
+	},
+	{
+		"id": "5e7d127361152432f36e9c54",
+		"firstname": "Franco",
+		"lastname": "Fioravanti",
+		"email": "franco.fiora@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/60f59b9ff026ab007012bd00/47395d76-956e-4df7-a0db-cd8ab74ddd02/48",
+		"status": "active"
+	},
+	{
+		"id": "5e7d192361152432f370f095",
+		"firstname": "Fernando",
+		"lastname": "Colom",
+		"email": "fernando.colom@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5a8afe1fa08cc5310a6d082d/b94858d4-cfe8-4917-9711-44d21aa02e7d/48",
+		"status": "active"
+	},
+	{
+		"id": "60dc8d21d2db229ce2b077bc",
+		"firstname": "Sebastian",
+		"lastname": "Vitielo",
+		"email": "sebastian.vitielo@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5f282f1970fb250022e861ec/4f9150d8-8f60-4af9-a5ae-5baeb9454d0c/48",
+		"status": "active"
+	},
+	{
+		"id": "6336dcf381f2a0af54ab2d11",
+		"firstname": "Mauro",
+		"lastname": "Arteaga",
+		"email": "mauro.arteaga@janis.im",
+		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/63aee3bd030d706ab0e4894d/98761154-d197-44a5-ad85-f7d03d15f88d/48",
+		"status": "active"
+	}
+]

--- a/src/components/AvatarGroup/usersMock.json
+++ b/src/components/AvatarGroup/usersMock.json
@@ -4,7 +4,7 @@
 		"firstname": "Damian",
 		"lastname": "Giannico",
 		"email": "damian.giannico@janis.im",
-		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/631268b155b0a9e29f1b4026/5a3ee1ac-7da5-4a4c-a198-fa4c9fe7c3a6/48",
+		"mainColor": "lightBlue",
 		"status": "active"
 	},
 	{
@@ -16,11 +16,15 @@
 		"status": "active"
 	},
 	{
+		"id": "5dcda8a703d3922d3c1ae19e",
+		"email": "empty@janis.im",
+		"status": "active"
+	},
+	{
 		"id": "5e7d127361152432f36e9c54",
 		"firstname": "Franco",
-		"lastname": "Fioravanti",
+		"mainColor": "green",
 		"email": "franco.fiora@janis.im",
-		"url": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/60f59b9ff026ab007012bd00/47395d76-956e-4df7-a0db-cd8ab74ddd02/48",
 		"status": "active"
 	},
 	{

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import Avatar from './Avatar';
+import AvatarGroup from './AvatarGroup';
 import Button from './Button';
 import Checkbox from './Checkbox';
 import Chip from './Chip';
@@ -20,6 +21,7 @@ import Skeleton from './Skeleton';
 export {
 	ErrorBoundary,
 	Avatar,
+	AvatarGroup,
 	Button,
 	Checkbox,
 	Chip,


### PR DESCRIPTION
**Link al ticket**
- https://janiscommerce.atlassian.net/browse/JMV-3293

**Descripción del requerimiento**
- Se necesita implementar el componente AvatarGroup en ui web, el mismo debe mostrar un listado de usuarios con su avatar utilizando el componente Avatar

**Criterios de aprobacion**
- Que se vean Avatars correspondientes a una lista de usuarios
- Que se pueda probar en Storybooks
- Que se utilice en Views
- Que la cantidad de usuarios a mostrar sea editable y muestre el + cuando se supera

**Descripción de la solución**
- Se creó el componente AvatarGroup, que en base a una lista de usuarios, muestra una lista de Avatars utilizando el componente Avatar

**Cómo se puede probar?**
**Para probarlo en Storybook**
- Levantar la rama y correr el comando `yarn storybook`
- Ingresar en [AvatarGroup](http://localhost:6006/?path=/story/components-avatargroup--with-four-avatars)

**Para probarlo en Views**
Iniciando el proyecto UI-WEB en la rama actual
Borrar node_modules en caso de tenerlos
Correr comando yarn
Luego correr comando yarn build
Y para finalizar correr el comando yalc publish
Luego ingresamos a Views puede hacerse sobre beta, sino

Ingresar a JMV-3288-deploy que es la uncia rama que actualmente tiene el AvatarGroup
Bajar el docker
Borrar node_modules en caso de tenerlos
Correr el comando yalc add @janiscommerce/ui-web
Correr comando npm i
Levantar el docker

En el archivo AvatarGroup, importar el componente AvatarGroup de uiweb, deberia quedar asi
![image](https://github.com/janis-commerce/ui-web/assets/64233677/30f96d88-caea-4f99-b4b8-c6f251ca10d4)

Se puede validar que funcione todo en [Calendar](http://janis.localhost:3001/delivery/driver/planning?filters[firstname]=s)

**Evidencias, pruebas de como funciona**
- Del lado de uiweb, ya no hay que hacer nada, pero del lado de Views, cuando se implemente el AvatarGroup en Views, se debe mediante una funcion, agregarle un mainColor en cada usuario usando la misma función que hoy usamos en UserImage para sortear los colores del avatar
- Hoy el componente recibe un color por default, si no se realiza esto, al momento de ustilizarse se ceran todos los avatar de iniciales con el mismo color

**Con la funcion en Views**
![image](https://github.com/janis-commerce/ui-web/assets/64233677/79f94bea-636d-4885-bc86-0e6a94843cfa)
**Sin la funcion de colores** 
![image](https://github.com/janis-commerce/ui-web/assets/64233677/9bd34035-1406-4212-910a-b73d5d8fd1f8)


**Datos extra a tener en cuenta**
Va a requerir un cambio de Views cuando se aplique para que use las funciones que usamos en Avatar para generar el color

**Changelog**
- Added: AvatarGroup component