### PR TITLE
JMV-3297-Hacer-deploy-de-storybooks-al-publicar-en-npm

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,46 @@
+name: publish-docs
+
+on: workflow_dispatch
+
+jobs:
+  build-and-deploy-storybooks:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    concurrency:
+      group: 'pages'
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Build docs Storybooks
+        run: |
+          npm install
+          npm run storybook-web-docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: './docs/'
+          name: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+        with:
+          artifact_name: 'docs'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"test-ci": "JEST_JUNIT_OUTPUT_DIR=test-reports jest --coverage --silent --ci --reporters=jest-junit",
 		"coverage": "jest --coverage --silent",
 		"storybook": "start-storybook -p 6006 -s public",
-		"build:storybook": "build-storybook -c .storybook -o ./stories",
+		"storybook-web-docs": "build-storybook --config-dir ./.storybook --output-dir ./docs",
 		"deploy-storybook": "gh-pages -d stories",
 		"build:icons": "node scripts/build-icons",
 		"postpublish": "bash ./.postpublish.sh"


### PR DESCRIPTION
## Link al ticket 

https://janiscommerce.atlassian.net/browse/JMV-3297

## Descripción del requerimiento

Poder automatizar el deploy que hacemos en github pages para que se haga cuando hagamos una nueva release en la creación de una nueva versión. Todo esto debe suceder mediante las acciones de github y solo si la publicación de la nueva versión haya impactado en npm.

## Descripción de la solución

Se migró un workflow existente con el mismo propósito desde ui-native, a modo de prueba este mismo solo se puede ejecutar a través de un trigger manualmente. Una vez probado su funcionamiento la idea es realizar un nuevo pr quitando este workflow y agregándolo como una nueva tarea dentro del workflow npm-publish.

## Cómo se puede probar?

Una vez mergeada la rama este workflow aparecerá dentro de la tab Actions, y solo faltaría buscar el workflow publish-docs, ejecutarlo y corroborar en log que las tareas sean exitosas.

## Changelog

Added: publish-docs workflow