### PR TITLE
Jmv 3363 dar imagen de janis a la documentacion

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,13 @@
+<!-- .storybook/preview-head.html -->
+
+<!-- Pull in static files served from your Static directory or the internet -->
+<!-- Example: `main.js|ts` is configured with staticDirs: ['../public'] and your font is located in the `fonts` directory inside your `public` directory -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;900&display=swap" rel="stylesheet">
+
+<!-- Or you can load custom head-tag JavaScript: -->
+
+<style>
+    * {font-family: 'Roboto'}
+</style>

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import viewsPalette from 'theme/palette';
 import Avatar from './Avatar';
+import AvatarDocs from './AvatarDocs';
 
 const control = {
 	type: 'select',
@@ -14,7 +15,10 @@ export default {
 	title: 'Components/Avatar',
 	component: Avatar,
 	parameters: {
-		layout: 'centered'
+		layout: 'centered',
+		docs: {
+			page: () => <AvatarDocs title="Avatar" />
+		}
 	},
 	argTypes: {
 		mainColor: { control },

--- a/src/components/Avatar/AvatarDocs.jsx
+++ b/src/components/Avatar/AvatarDocs.jsx
@@ -1,0 +1,74 @@
+import { Story, Canvas } from '@storybook/addon-docs/blocks';
+import { HeaderDoc, SectionDoc } from 'docs';
+import { GeneralWrapper, VariantWrapper } from 'docs/docStyles';
+import PropTypes from 'prop-types';
+import Avatar from './Avatar';
+
+const avatarStories = [
+	{ size: 'small', description: 'Small', type: 'Initials' },
+	{
+		size: 'medium',
+		description: 'Medium',
+		type: 'Picture',
+		url: 'https://media.admagazine.com/photos/637d11a6e63c8afac40e7a01/1:1/w_2896,h_2896,c_limit/1442809583'
+	},
+	{
+		size: 'large',
+		description: 'Large',
+		type: 'Logo',
+		url: 'https://cdn.id.janis.in/client-images/5ec2d43b70cd6700077c3aa1/0cdc0141-1f76-465a-8a06-8512b289eb85.png'
+	}
+];
+
+const AvatarDocs = ({ title }) => {
+	return (
+		<GeneralWrapper>
+			<HeaderDoc title={title} />
+			<SectionDoc title="Component" padding={'1rem'}>
+				<h1>Hola</h1>
+				<p>
+					Small image or icon representing a user within a digital interface. Avatars add a personal
+					touch and aid in quick user recognition.
+				</p>
+			</SectionDoc>
+
+			<SectionDoc title="Copy Me">
+				<Canvas>
+					<Story id="components-avatar--with-url" />
+				</Canvas>
+			</SectionDoc>
+
+			<SectionDoc title="Variants">
+				<VariantWrapper>
+					<div className="type">
+						<p>Size</p>
+					</div>
+					{avatarStories.map((storySize) => (
+						<div key={storySize.size} className="stories">
+							<p>{storySize.description}</p>
+							<Avatar size={storySize.size} />
+						</div>
+					))}
+				</VariantWrapper>
+			</SectionDoc>
+			<SectionDoc>
+				<VariantWrapper>
+					<div className="type">
+						<p>Type</p>
+					</div>
+					{avatarStories.map(({ size, type, url }) => (
+						<div key={size} className="stories">
+							<p>{type}</p>
+							<Avatar size={'large'} firstname={'Lionel'} url={url ? url : ''} />
+						</div>
+					))}
+				</VariantWrapper>
+			</SectionDoc>
+		</GeneralWrapper>
+	);
+};
+export default AvatarDocs;
+
+AvatarDocs.propTypes = {
+	title: PropTypes.string.isRequired
+};

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Button from './Button';
 import { validColors } from './utils';
 import icons from '../Icon/icons.json';
+import ButtonDoc from './ButtonDoc';
 
 const control = {
 	type: 'select',
@@ -15,7 +16,10 @@ export default {
 	title: 'Components/Button',
 	component: Button,
 	parameters: {
-		layout: 'centered'
+		layout: 'centered',
+		docs: {
+			page: () => <ButtonDoc title="Button" />
+		}
 	},
 	argTypes: {
 		variant: ['cleaned', 'contained', 'outlined'],

--- a/src/components/Button/ButtonDoc.jsx
+++ b/src/components/Button/ButtonDoc.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { Story, Canvas } from '@storybook/addon-docs/blocks';
+import { HeaderDoc, SectionDoc } from 'docs';
+
+const ButtonDoc = ({ title }) => {
+	return (
+		<div style={{ background: '#EAEBED', paddingBottom: '1rem' }}>
+			<HeaderDoc title={title} />
+			<SectionDoc title="Component" padding={'1rem'}>
+				<h2>{title}</h2>
+				<p>
+					Small image or icon representing a user within a digital interface. Avatars add a personal
+					touch and aid in quick user recognition.
+				</p>
+			</SectionDoc>
+			<SectionDoc title="Copy Me">
+				<Canvas>
+					<Story id="components-button--contained" />
+				</Canvas>
+			</SectionDoc>
+			<SectionDoc padding={'1rem'}>
+				<h1>Section sin title</h1>
+			</SectionDoc>
+			<SectionDoc title="Section con title" padding={'1rem'}>
+				<p>Section con title</p>
+			</SectionDoc>
+		</div>
+	);
+};
+export default ButtonDoc;
+
+ButtonDoc.propTypes = {
+	title: PropTypes.string
+};

--- a/src/components/Button/ButtonDoc.jsx
+++ b/src/components/Button/ButtonDoc.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import { Story, Canvas } from '@storybook/addon-docs/blocks';
 import { HeaderDoc, SectionDoc } from 'docs';
+import { GeneralWrapper } from 'docs/docStyles';
 
 const ButtonDoc = ({ title }) => {
 	return (
-		<div style={{ background: '#EAEBED', paddingBottom: '1rem' }}>
+		<GeneralWrapper>
 			<HeaderDoc title={title} />
 			<SectionDoc title="Component" padding={'1rem'}>
 				<h2>{title}</h2>
@@ -24,7 +25,7 @@ const ButtonDoc = ({ title }) => {
 			<SectionDoc title="Section con title" padding={'1rem'}>
 				<p>Section con title</p>
 			</SectionDoc>
-		</div>
+		</GeneralWrapper>
 	);
 };
 export default ButtonDoc;

--- a/src/docs/HeaderDoc.jsx
+++ b/src/docs/HeaderDoc.jsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import viewsPalette from 'theme/palette';
+import PropTypes from 'prop-types';
+
+const Header = styled.header`
+	background-color: ${viewsPalette.blue};
+	padding: 2rem 4rem;
+	margin: 0;
+	color: ${viewsPalette.white};
+
+	div {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	p {
+		font-size: 1 rem;
+	}
+
+	h1 {
+		font-size: 50px;
+		font-weight: 500;
+	}
+`;
+
+export const HeaderDoc = ({ title }) => {
+	return (
+		<Header>
+			<div>
+				<p>Design System</p>
+				<p>Documentacion</p>
+			</div>
+			<h1>{title}</h1>
+		</Header>
+	);
+};
+
+HeaderDoc.propTypes = {
+	title: PropTypes.string.isRequired
+};

--- a/src/docs/SectionDoc.jsx
+++ b/src/docs/SectionDoc.jsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import viewsPalette from 'theme/palette';
+import PropTypes from 'prop-types';
+
+const Wrapper = styled.section`
+	max-width: 800px;
+	margin-inline: auto;
+
+	article {
+		padding: ${({ padding }) => (padding ? padding : '0')};
+		border-radius: 0.5rem;
+		background: ${viewsPalette.white};
+	}
+`;
+
+const SubTitle = styled.h2`
+	background: ${viewsPalette.blue};
+	color: ${viewsPalette.white};
+	padding: 1rem;
+	font-size: 1.2rem;
+	border-radius: 0.5rem;
+	margin-top: 4rem;
+`;
+
+export const SectionDoc = ({ title, children, padding }) => {
+	return (
+		<Wrapper padding={padding}>
+			{title && <SubTitle>{title}</SubTitle>}
+			<article> {children}</article>
+		</Wrapper>
+	);
+};
+
+SectionDoc.propTypes = {
+	title: PropTypes.string,
+	children: PropTypes.node,
+	padding: PropTypes.string
+};

--- a/src/docs/docStyles.js
+++ b/src/docs/docStyles.js
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import viewsPalette from 'theme/palette';
+
+export const GeneralWrapper = styled.div`
+	background: #eaebed;
+	padding-bottom: 4rem;
+`;
+
+export const VariantWrapper = styled.article`
+ background: ${viewsPalette.white};
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  justify-content: start;
+  align-content: start;
+  margin-top: 1rem;
+
+	.type {
+		background: #f6f6f6;
+    padding: 1rem;
+    border-radius: 0.5rem 0 0 0.5rem;
+	}
+
+	.stories {
+	  padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: center;
+    position: relative;
+    height: 150px;
+    
+    p {
+    align-self: start;
+    margin-bottom: 3rem;
+    font-size: 1rem;
+    }
+	}
+
+	div:nth-child(3) {
+		border-inline: 1px solid #D5D7DB;
+    width: 100%
+    margin: 0 auto;
+    align-self: start;
+	}
+`;

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -1,0 +1,4 @@
+import { HeaderDoc } from './HeaderDoc';
+import { SectionDoc } from './SectionDoc';
+
+export { HeaderDoc, SectionDoc };


### PR DESCRIPTION
**Link al ticket** 
- https://janiscommerce.atlassian.net/browse/JMV-3363

**Descripción del requerimiento**

Necesitamos mejorar hoy como se ven los distintos componentes dado que la documentación no es clara, no respeta la imagen de Janis y queremos que sea una documentación mucho más útil para cualquier desarrollador que quiera usar la librería

**Criterios de aprobacion**

El objetivo seria avanzar con el cambio de fuentes y creacion de componente reutilizable que muestre el titulo de cada componente. Como evolutivo se plantearan otras mejoras

**Descripcion de la solucion**

- Se agrego el archivo `preview-head.html` en donde se agrega la fuente Roboto
- Se crearon los componentes `SectionDoc, HeaderDoc` con sus respectivos estilos, que seran reutilizables en cada una de las documentaciones de los componentes.
- Se agregaron dos muestras de documentacion en los componentes en `Avatar` como en `Button`

**Cómo se puede probar?**
- Levantar la rama con `yarn storybook`
- Ver [Avatar](http://localhost:6006/?path=/docs/components-avatar--with-name)

**Componente `SectionDocx`**
Este componente recibe por `props` tres valores, `title, children y padding` esta pensado para que sea una seccion en donde se pueda renderizar un children con la informacion necesaria. Ademas puede mostrar o no el titulo y agregar padding o no

Ejemplo de sections
![image](https://github.com/janis-commerce/ui-web/assets/20828877/80afc931-fc75-4795-8651-219e9604edd9)


**Componente `HeaderDoc`**
Este componente recibe por prop unicamente el `title` para renderizar al inicio de la doc
![image](https://github.com/janis-commerce/ui-web/assets/20828877/4518ff95-b373-48ad-a6fd-1bb6af3fabb8)

**Como se puede probar?**
Se debe crear un componente `NombreComponenteDoc.jsx` importar `HeaderDoc y SectionDoc` y escribir la info del componente.
En la historia del componente se debe de agregar la documentacion linkeando el componente de documentacion

```
parameters: {
		layout: 'centered',
		docs: {
			page: () => <AvatarDocs title="Avatar" />
		}
	},
``` 

**Changelog**
- Added: Roboto Font & Reusable components for docs
