### PR TITLE
Export palette

### DIFF
--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useDevices from 'hooks/useDevices';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import { getImageMeasurements } from 'theme/utils';
 import Skeleton from 'components/Skeleton';
 import styled from './styles';
@@ -83,7 +83,7 @@ Avatar.defaultProps = {
 	size: 'small',
 	url: '',
 	rounded: true,
-	mainColor: viewsPalette.grey
+	mainColor: palette.grey
 };
 
 export default Avatar;

--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Avatar from './Avatar';
 import AvatarDocs from './AvatarDocs';
 import { DocComponent } from 'docs/DocComponent';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Avatar/components/InitialsAvatar/styles.js
+++ b/src/components/Avatar/components/InitialsAvatar/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import mixins from 'theme/mixins';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export default {
 	Initials: styled.div`
@@ -8,7 +8,7 @@ export default {
 		height: ${({ size }) => size};
 		border-radius: ${({ rounded }) => (rounded ? '50%' : '3px')};
 		font-weight: 500;
-		color: ${viewsPalette.white};
+		color: ${palette.white};
 		background-color: ${({ color }) => color};
 		text-transform: uppercase;
 		${mixins.flexCenter};

--- a/src/components/AvatarGroup/AvatarGroup.js
+++ b/src/components/AvatarGroup/AvatarGroup.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from 'components/Avatar';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import styled from './styles';
 import AvatarList from './components/AvatarList';
 
@@ -41,7 +41,7 @@ AvatarGroup.propTypes = {
 };
 
 AvatarGroup.defaultProps = {
-	badgeColor: viewsPalette.blue,
+	badgeColor: palette.blue,
 	users: [],
 	usersToDisplay: 5,
 	showFull: false

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import AvatarGroup from './AvatarGroup';
 import users from './usersMock.json';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/AvatarGroup/styles.js
+++ b/src/components/AvatarGroup/styles.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import Chip from 'components/Chip';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export default {
 	AvatarGroup: styled(Chip)`
@@ -14,7 +14,7 @@ export default {
 						max-width: inherit;
 						&:hover,
 						&:active {
-							background: ${backgroundColor || viewsPalette.white};
+							background: ${backgroundColor || palette.white};
 						}
 				  `
 				: css`
@@ -23,12 +23,12 @@ export default {
 						padding-right: 5px;
 						cursor: pointer;
 				  `}
-		background: ${({ backgroundColor }) => backgroundColor || viewsPalette.white};
+		background: ${({ backgroundColor }) => backgroundColor || palette.white};
 		${({ inactive }) =>
 			inactive &&
 			`
            &:hover {
-               background: ${viewsPalette.white};
+               background: ${palette.white};
            }
            &:active {
                border-color: #EAEBED;

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -3,7 +3,7 @@ import Button from 'components/Button';
 import Icon from 'components/Icon';
 import { getColor, getHoverColor, getPressedColor } from './utils';
 import { create } from 'react-test-renderer';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 describe('Button component', () => {
 	describe('Component', () => {
@@ -57,21 +57,21 @@ describe('Button component', () => {
 		const exampleColors = [
 			{
 				color: 'blue',
-				valueColor: viewsPalette.blue,
-				valueHover: viewsPalette.blueHover,
-				valuePressed: viewsPalette.bluePressed
+				valueColor: palette.blue,
+				valueHover: palette.blueHover,
+				valuePressed: palette.bluePressed
 			},
 			{
 				color: 'black',
-				valueColor: viewsPalette.black,
-				valueHover: viewsPalette.blackHover,
-				valuePressed: viewsPalette.blackPressed
+				valueColor: palette.black,
+				valueHover: palette.blackHover,
+				valuePressed: palette.blackPressed
 			},
 			{
 				color: 'grey',
-				valueColor: viewsPalette.grey,
-				valueHover: viewsPalette.greyHover,
-				valuePressed: viewsPalette.greyPressed
+				valueColor: palette.grey,
+				valueHover: palette.greyHover,
+				valuePressed: palette.greyPressed
 			}
 		];
 
@@ -79,9 +79,9 @@ describe('Button component', () => {
 
 		test('Should returns default colors', () => {
 			exampleInvalidColors.forEach((color) => {
-				expect(getColor(color)).toEqual(viewsPalette.blue);
-				expect(getHoverColor(color)).toEqual(viewsPalette.blueHover);
-				expect(getPressedColor(color)).toEqual(viewsPalette.bluePressed);
+				expect(getColor(color)).toEqual(palette.blue);
+				expect(getHoverColor(color)).toEqual(palette.blueHover);
+				expect(getPressedColor(color)).toEqual(palette.bluePressed);
 			});
 		});
 

--- a/src/components/Button/utils.js
+++ b/src/components/Button/utils.js
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { getColor as findColorInTheme } from 'theme/utils';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export const validColors = [
 	'black',
@@ -18,16 +18,16 @@ export const validColors = [
 	'yellow'
 ];
 
-const { white, grey, lightGreyHover, lightGrey, blue, blueHover, bluePressed } = viewsPalette;
+const { white, grey, lightGreyHover, lightGrey, blue, blueHover, bluePressed } = palette;
 
 const isValidColor = (color) => validColors.includes(color);
-export const getColor = (color) => (isValidColor(color) ? viewsPalette[color] : blue);
+export const getColor = (color) => (isValidColor(color) ? palette[color] : blue);
 
 export const getHoverColor = (color) =>
-	isValidColor(color) ? viewsPalette[`${color}Hover`] : blueHover;
+	isValidColor(color) ? palette[`${color}Hover`] : blueHover;
 
 export const getPressedColor = (color) =>
-	isValidColor(color) ? viewsPalette[`${color}Pressed`] : bluePressed;
+	isValidColor(color) ? palette[`${color}Pressed`] : bluePressed;
 
 const commonStyles = (iconColor, fontColor, color) => css`
 	color: ${findColorInTheme(fontColor || color || blue)};

--- a/src/components/Chip/Chip.stories.js
+++ b/src/components/Chip/Chip.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import icons from '../Icon/icons.json';
 import Chip from './Chip';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Color/Color.stories.js
+++ b/src/components/Color/Color.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Color from './Color';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Icon/AllIcons.stories.js
+++ b/src/components/Icon/AllIcons.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Icons from './Icons';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Icon from './Icon';
 import icons from './icons.json';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Icon/Icons.js
+++ b/src/components/Icon/Icons.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import { copyToClipboard } from 'utils';
 import { docz as styled } from './styles';
 import icons from './icons.json';
@@ -34,7 +34,7 @@ const Icons = ({ color }) => {
 
 Icons.propTypes = {
 	/** Color para cambiar el color de los iconos de la lista */
-	color: PropTypes.oneOf(Object.keys(viewsPalette))
+	color: PropTypes.oneOf(Object.keys(palette))
 };
 
 Icons.defaultProps = {

--- a/src/components/Image/Image.stories.js
+++ b/src/components/Image/Image.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Image from './Image';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Input/Input.stories.js
+++ b/src/components/Input/Input.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import Input from './Input';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Skeleton/Skeleton.stories.js
+++ b/src/components/Skeleton/Skeleton.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import Skeleton from './Skeleton';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 const control = {
 	type: 'select',
-	options: Object.keys(viewsPalette).reduce((options, colorName) => {
-		options[colorName] = viewsPalette[colorName];
+	options: Object.keys(palette).reduce((options, colorName) => {
+		options[colorName] = palette[colorName];
 		return options;
 	}, {})
 };

--- a/src/components/Skeleton/styles.js
+++ b/src/components/Skeleton/styles.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export default {
 	SkeletonContainer: styled.div`
 		border-radius: ${({ circle }) => (circle ? ' 50%' : '3px')};
 		height: ${({ height }) => height};
 		width: ${({ width }) => width};
-		background-color: ${({ backgroundColor }) => backgroundColor || viewsPalette.lightGrey};
+		background-color: ${({ backgroundColor }) => backgroundColor || palette.lightGrey};
 		animation: pulse 1.5s ease-in-out infinite;
 
 		@keyframes pulse {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,9 +17,9 @@ import Link from './Link';
 import Drawer from './Drawer';
 import ClickAwayListener from './ClickAwayListener';
 import Skeleton from './Skeleton';
+import viewsPalette from 'theme/palette';
 
 export {
-	ErrorBoundary,
 	Avatar,
 	AvatarGroup,
 	Button,
@@ -29,6 +29,7 @@ export {
 	Color,
 	ColorPicker,
 	Drawer,
+	ErrorBoundary,
 	HTML,
 	Icon,
 	Image,
@@ -37,5 +38,6 @@ export {
 	QRCode,
 	Skeleton,
 	Switch,
-	Textarea
+	Textarea,
+	viewsPalette
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,7 +17,7 @@ import Link from './Link';
 import Drawer from './Drawer';
 import ClickAwayListener from './ClickAwayListener';
 import Skeleton from './Skeleton';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export {
 	Avatar,
@@ -39,5 +39,5 @@ export {
 	Skeleton,
 	Switch,
 	Textarea,
-	viewsPalette
+	palette
 };

--- a/src/docs/HeaderDoc.jsx
+++ b/src/docs/HeaderDoc.jsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import PropTypes from 'prop-types';
 
 const Header = styled.header`
-	background-color: ${viewsPalette.blue};
+	background-color: ${palette.blue};
 	padding: 2rem 4rem;
 	margin: 0;
-	color: ${viewsPalette.white};
+	color: ${palette.white};
 
 	div {
 		display: flex;

--- a/src/docs/SectionDoc.jsx
+++ b/src/docs/SectionDoc.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 import PropTypes from 'prop-types';
 
 const Wrapper = styled.section`
@@ -9,13 +9,13 @@ const Wrapper = styled.section`
 	article {
 		padding: ${({ padding }) => (padding ? padding : '0')};
 		border-radius: 0.5rem;
-		background: ${viewsPalette.white};
+		background: ${palette.white};
 	}
 `;
 
 const SubTitle = styled.h2`
-	background: ${viewsPalette.blue};
-	color: ${viewsPalette.white};
+	background: ${palette.blue};
+	color: ${palette.white};
 	padding: 1rem;
 	font-size: 1.2rem;
 	border-radius: 0.5rem;

--- a/src/docs/docStyles.js
+++ b/src/docs/docStyles.js
@@ -1,20 +1,20 @@
 import styled from 'styled-components';
-import viewsPalette from 'theme/palette';
+import palette from 'theme/palette';
 
 export const GeneralWrapper = styled.div`
-	background: ${viewsPalette.lightGrey};
+	background: ${palette.lightGrey};
 	padding-bottom: 4rem;
 `;
 
 export const VariantWrapper = styled.article`
-	background: ${viewsPalette.white};
+	background: ${palette.white};
 	display: flex;
 	justify-content: flex-start;
 	margin-top: 1rem;
 	box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
 	.type {
-		background: ${viewsPalette.lightGreyHover};
+		background: ${palette.lightGreyHover};
 		padding: 1rem;
 		border-radius: 0.5rem 0 0 0.5rem;
 		width: 150px;
@@ -28,7 +28,7 @@ export const GridWrapper = styled.div`
 
 	.stories {
 		padding: 1rem;
-		border: 1px solid ${viewsPalette.lightGreyHover};
+		border: 1px solid ${palette.lightGreyHover};
 		min-height: 200px;
 		display: flex;
 		flex-direction: column;

--- a/src/theme/Colors.js
+++ b/src/theme/Colors.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { storybook as styled } from 'theme/styles';
-import viewsPallet from 'theme/palette';
+import palette from 'theme/palette';
 import { Color, Input } from 'components';
 
-const colors = Object.entries(viewsPallet);
+const colors = Object.entries(palette);
 
 const Colors = () => {
 	const [searchTerm, setSearchTerm] = useState('');

--- a/src/theme/palette.js
+++ b/src/theme/palette.js
@@ -27,7 +27,6 @@ const viewsPalette = {
 	lightGrey: '#E8EAF6',
 	lightGreyHover: '#F4F5FB',
 	lightGreyPressed: '#D0D3E3',
-	lightGreySelected: '#E4ECFA',
 	lightTurquoise: '#BBE9D6',
 	magenta: '#ED14A4',
 	orange: '#FF8D10',

--- a/src/theme/palette.js
+++ b/src/theme/palette.js
@@ -1,4 +1,4 @@
-const viewsPalette = {
+const palette = {
 	black: '#2F2F2F',
 	blackHover: '#585858',
 	blackPressed: '#16232D',
@@ -52,4 +52,4 @@ const viewsPalette = {
 	yellowPressed: '#FFBA0C'
 };
 
-export default viewsPalette;
+export default palette;


### PR DESCRIPTION
**Link al ticket**
https://janiscommerce.atlassian.net/browse/JMV-3608

**Descripción del requerimiento**
Se necesita exportar la paleta de colores de ui-web
Eliminar un color que está duplicado

**Descripción de la solución**
Se agregó a la lista exportable la paletta de colores
Los colores repetidos eran `lightGreySelected` y `blueAvailable`, ambos se utilizan una unica vez en `Views`, el mas nuevo es `blueAvailable`, sin embargo me pareció mejor al nombrado para dejar ese y eliminar el `lightGreySelected`

**¿Cómo se puede probar?**

**Para probarlo en Views**
- Iniciando el proyecto UI-WEB en la rama actual
- Borrar `node_modules` en caso de tenerlos
- Correr comando `yarn`
- Luego correr comando `yarn build`
- Y para finalizar correr el comando `yalc publish`

Luego ingresamos a Views

- Ingresar a `beta` o `master` (es solo para probar)
- Bajar el docker
- Borrar node_modules en caso de tenerlos
- Correr el comando yalc add @janiscommerce/ui-web
- Correr comando npm i
- Levantar el docker 

Luego desde el repo de `Views`

- Ingresar al archivo `src/theme.js`, 
- Importar de `@janiscommerce/ui-web` la paleta 
`import { palette } from '@janiscommerce/ui-web';`

- Eliminar el objeto de colores de theme.colors y dejarlo asi:
`colors: palette,`

Tener en cuenta que el color `lightGreySelected` ya no existe en la paleta, por lo que ene l lugar que se utiliza no se va a ver, se corrige en el PR que se actualice UI web
![image](https://github.com/user-attachments/assets/e486768d-9e01-4248-b35c-d18d5bf329b9)
![image](https://github.com/user-attachments/assets/d34287ac-8e9e-4c22-bf70-6d240d803c25)

**Screenshot**
![image](https://github.com/user-attachments/assets/bc150004-4f43-4060-bb87-7f9f5a162a8a)
