### PR TITLE
add peerDependencies upper posibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
 		"testEnvironment": "jsdom"
 	},
 	"peerDependencies": {
-		"react": "17.x",
-		"react-dom": "17.x",
+		"react": "<= 17.x",
+		"react-dom": "<= 17.x",
 		"styled-components": "<= 5.3.0"
 	},
 	"babel": {


### PR DESCRIPTION
**CONTEXTO**
Actualmente estamos intentando acceder al paquete desde una landing que utiliza react 18

Al momento de instalar la dependencia, está arrojando en algunos casos error de compatibilidad

**NECESIDAD**
Actualizar el valor de la version de react y react dom en  peerDependencies para poder utilizarlo en un contexto con react mayor al 17