### PR TITLE
Fix with config

### DIFF
--- a/src/components/Skeleton/Skeleton.js
+++ b/src/components/Skeleton/Skeleton.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from './styles';
+import { SkeletonContainer } from './styles';
 
 const Skeleton = ({ circle, width, height, count, backgroundColor }) => {
 	const currentWidth = !Number.isNaN(Number(width)) ? `${width}px` : width;
 	const currentHeight = !Number.isNaN(Number(height)) ? `${height}px` : height;
 
 	const skeletons = Array.from({ length: count }, (_, index) => (
-		<styled.SkeletonContainer
+		<SkeletonContainer
 			key={index}
 			width={currentWidth}
 			height={currentHeight}

--- a/src/components/Skeleton/styles.js
+++ b/src/components/Skeleton/styles.js
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 import palette from 'theme/palette';
 
-export default {
-	SkeletonContainer: styled.div`
+export const SkeletonContainer = styled.div`
 		border-radius: ${({ circle }) => (circle ? ' 50%' : '3px')};
 		height: ${({ height }) => height};
 		width: ${({ width }) => width};
@@ -21,4 +20,4 @@ export default {
 			}
 		}
 	`
-};
+


### PR DESCRIPTION
Estamos teniendo un problema a la hora de utilizar la librería en la landing de pickup, esto sucede con el solo hecho de utilizar algo exportado desde aca, ya sea un componente o la paleta por ej

Se hicieron varias pruebas de cambios en configuración y todo lleva a el mismo error, al momento de subirlo a beta nos rompe la vista y no detecta el withConfig

withConfig es una función interna utilizada por styled-components para manejar la configuración personalizada de los componentes de estilo. Según vi, aunque no lo usemos directamente en el código, styled-components puede estar inyectando esta funcionalidad internamente durante el proceso de buildeo

Para descartar que el caso sea particular de la landing de pickup, cree un repo propio privado, en el que utilice la libreria, un comonente y lo [subi a vercel](https://testing-sooty-iota-65.vercel.app/), si revisan la consola nos arroja el mismo error que venimos viendo en la landing, por lo que veo que el withCOnfig quien lo inyecta es la librería

Revisando sus node_modules, encontramos en el index.umd del dist los withConfig

Si seguimos al error desde la consola nos lleva al componente Skeleton 
![image](https://github.com/user-attachments/assets/8b6df4ef-5c98-4303-a381-1ac50ee10b4b)

Este problema nos sucede solamente en beta al deployar, si utilizamos local no nos rompe nada y funciona bien, por lo que corri la librería con yalc, 
En ese caso, el error cambia por que apunta al div sin tener un withConfig, por lo que probé modificando el export del componente en cuestión (SkeletonCOntainer)
En lugar de exportarlo como un objeto default lo declare como constante y lo exporte solo, y para usarlo hice lo mismo, de esa manera en el yalc no me rompió