### PR TITLE
Change rollups

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
 	"name": "@janiscommerce/ui-web",
 	"version": "0.24.0",
 	"description": "",
-	"main": "dist/index.umd.js",
+	"exports": {
+		".": {
+			"import": "dist/index.esm.js",
+			"require": "dist/index.umd.js"
+		}
+	},	
 	"private": false,
 	"scripts": {
 		"start": "rollup -c rollup/rollup.config.dev.js -w",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
 	"name": "@janiscommerce/ui-web",
 	"version": "0.24.0",
 	"description": "",
+	"main": "dist/index.umd.js",
 	"exports": {
 		".": {
-			"import": "dist/index.esm.js",
-			"require": "dist/index.umd.js"
+			"import": "dist/index.esm.js"
 		}
 	},	
 	"private": false,

--- a/rollup/rollup.config.dev.js
+++ b/rollup/rollup.config.dev.js
@@ -20,7 +20,10 @@ export default [
 				sourcemap: true
 			}
 		],
-		plugins: plugins(ENV)
+		plugins: [
+			...plugins(ENV),
+			livereload({ watch: 'dev' }) // Corrección del nombre de la función 'livereload'
+		]
 	},
 	{
 		input: 'example/index.js',
@@ -39,7 +42,7 @@ export default [
 				host: 'localhost',
 				port: 3000
 			}),
-			livereload({ watch: 'dev' })
+			livereload({ watch: 'dev' }) // Corrección del nombre de la función 'livereload'
 		]
 	}
 ];

--- a/rollup/rollup.config.dev.js
+++ b/rollup/rollup.config.dev.js
@@ -22,7 +22,7 @@ export default [
 		],
 		plugins: [
 			...plugins(ENV),
-			livereload({ watch: 'dev' }) // Corrección del nombre de la función 'livereload'
+			livereload({ watch: 'dev' })
 		]
 	},
 	{
@@ -42,7 +42,7 @@ export default [
 				host: 'localhost',
 				port: 3000
 			}),
-			livereload({ watch: 'dev' }) // Corrección del nombre de la función 'livereload'
+			livereload({ watch: 'dev' })
 		]
 	}
 ];

--- a/rollup/rollup.config.dev.js
+++ b/rollup/rollup.config.dev.js
@@ -7,12 +7,19 @@ const ENV = 'development';
 export default [
 	{
 		input: 'src/components/index.js',
-		output: {
-			name: 'main',
-			file: 'dev/index.umd.js',
-			format: 'umd',
-			sourcemap: true
-		},
+		output: [
+			{
+				file: 'dist/index.esm.js',
+				format: 'esm',
+				sourcemap: true
+			},
+			{
+				name: 'main',
+				file: 'dev/index.umd.js',
+				format: 'umd',
+				sourcemap: true
+			}
+		],
 		plugins: plugins(ENV)
 	},
 	{

--- a/rollup/rollup.config.prod.js
+++ b/rollup/rollup.config.prod.js
@@ -8,19 +8,12 @@ const ENV = 'production';
 export default [
 	{
 		input: 'src/components/index.js',
-		output: [
-			{
-				file: 'dist/index.esm.js',
-				format: 'esm',
-				sourcemap: true
-			},
-			{
-				name: 'main',
-				file: 'dist/index.umd.js',
-				format: 'umd',
-				sourcemap: true
-			}
-		],
+		output: {
+			name: 'main',
+			file: 'dist/index.umd.js',
+			format: 'umd',
+			sourcemap: true
+		},
 		plugins: [
 			...plugins(ENV),
 			peerDepsExternal(),
@@ -43,5 +36,14 @@ export default [
 				}
 			})
 		]
+	},
+	{
+		input: 'src/components/index.js',
+		output: {
+			file: 'dist/index.esm.js',
+			format: 'es',
+			sourcemap: true
+		},
+		plugins: [...plugins(ENV), peerDepsExternal()]
 	}
 ];

--- a/rollup/rollup.config.prod.js
+++ b/rollup/rollup.config.prod.js
@@ -8,12 +8,19 @@ const ENV = 'production';
 export default [
 	{
 		input: 'src/components/index.js',
-		output: {
-			name: 'main',
-			file: 'dist/index.umd.js',
-			format: 'umd',
-			sourcemap: true
-		},
+		output: [
+			{
+				file: 'dist/index.esm.js',
+				format: 'esm',
+				sourcemap: true
+			},
+			{
+				name: 'main',
+				file: 'dist/index.umd.js',
+				format: 'umd',
+				sourcemap: true
+			}
+		],
 		plugins: [
 			...plugins(ENV),
 			peerDepsExternal(),


### PR DESCRIPTION
**CONTEXTO**
AL momento de utilizar la librería ui-web en la landing de pickup, nos esta sucediendo que nos arroja errores en la detección de los componentes exportados

Para poder replicar el error, se levanto todo en un repo en local y haciendo pruebas pude llegar a un error en los componentes exportados en el archivo `umd`, ya que el mismo en vite no los detectaba y arrojaba error que el componente no era exportado en ese archivo

Recorriendo docu y foros, se encontró que vite al momento de compilar puede estar resolviendo mal las dependencias con los archivos `umd`, por lo que se recomienda usar formato `esm`

El archivo `umd` se genera en los archivos `rollup`, el `rollup` compila todo el componente y lo devuelve compilado en un archivo umd, ya que estamos enviando en `output` (archivo generado en el `buidl`) algo asi:
`{
 name: 'main',
 file: 'dist/index.umd.js',
 format: 'umd',
 sourcemap: true
}`

Esto genera el build en el archivo `.umd`, lo que haciendo pruebas parece que vite no lee bien sus `exports`

**NECESIDAD**
Probar si generando ademas del archivo `.umd` también un archivo `.esm`, funciona bien primero la landing y luego `views`

**SOLUCION**
- Se agregó el caso para generar tambien el esm en ambos `rollup` para que además de crear el archivo `.umd`, también genere el `.esm` y funcione correctamente en vite

**COMO SE PUEDE PROBAR**
Para poder replicar el error exacto, se puede crear un repo nuevo (`npm create vite@latest`) en vite o hacerlo directo de la landing

desde ui-web, probando de master debería verse el error, desde la rama no

- Desde Ui-web,
Borrar node_modules y yarn-lock
Correr comando "yarn", esto genera el yarn lock nuevo e instala dependencias
Correr comando "yarn build" que crea la carpeta dist
Correr comando "yalc publish" para hacer publica la versión del paquete
**Nada mas desde Ui-web**

- Desde la landing o repo nuevo
Borrar node_modules
Correr comando  "yalc add @janiscommerce/ui-web" - Esto creara la carpeta yalc con el paquete adentro, y en el pakage.json realiza el cambio del paquete que quedaría asi: "@janiscommerce/ui-web": "file:.yalc/@janiscommerce/ui-web",
correr comando "npm i"
Importar y utilizar un componente  de la libreria, como por ej el Chip 
`import {Chip} from '@janiscommerce/ui-web'

 <Chip
          variant="contained"
          backgroundColor='red'
        >
          Chip
        </Chip>`
Correr `npm run dev`

Dependiendo en que rama este se detalló arriba si se ve o no el error

Si utilizamos la rama, el `yalc` debería generar ademas del archivo `.umd`, uno `.esm` en el dist
![image](https://github.com/user-attachments/assets/7d3b9591-a976-4631-a284-e355d859277b)


**A TENER EN CUENTA**
Una vez se suba esto hay que probar deployando a ver si se solucionó el problema
