### PR TITLE
Update publish-storybook.yml

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 
@@ -33,7 +33,7 @@ jobs:
           npm run storybook-web-docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './docs/'
           name: docs


### PR DESCRIPTION
Revisando deploy fallido, encontré que habría que versionar `artifacts` ya que depreco la v2, por lo que versiono directamente desde actions de github, también encontré que había para versionar setup_node  a v4

Si funciona bien, deberíamos hacer el mismo cambio en la action de npm-publish