### PR TITLE
add .jsx and plugin transform to plugins

### DIFF
--- a/rollup/plugins.js
+++ b/rollup/plugins.js
@@ -5,14 +5,34 @@ import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 export default (env) => [
-	replace({ 'process.env.NODE_ENV': JSON.stringify(env), preventAssignment: true }),
+	replace({
+		'process.env.NODE_ENV': JSON.stringify(env),
+		preventAssignment: true
+	}),
 	babel({
 		babelHelpers: 'bundled',
 		exclude: 'node_modules/**',
-		presets: ['@babel/preset-react'],
-		plugins: ['babel-plugin-styled-components', 'babel-plugin-transform-react-remove-prop-types']
+		extensions: ['.js', '.jsx'],
+		presets: [
+			'@babel/preset-react',
+			[
+				'@babel/preset-env',
+				{
+					targets: '> 0.25%, not dead',
+					useBuiltIns: 'usage',
+					corejs: 3
+				}
+			]
+		],
+		plugins: [
+			'babel-plugin-styled-components',
+			env === 'production' && 'babel-plugin-transform-react-remove-prop-types'
+		].filter(Boolean)
 	}),
-	nodeResolve({ moduleDirectories: ['node_modules', 'src'] }),
-	commonjs(),
+	nodeResolve({
+		moduleDirectories: ['node_modules', 'src'],
+		extensions: ['.js', '.jsx']
+	}),
+	commonjs({ exclude: ['node_modules'] }),
 	json()
 ];


### PR DESCRIPTION
**Link al ticket**
No hay

**Descripción del requerimiento**
Se encontró que al instalar la librería en un repo que utiliza vite, no se compila como debería al momento de utilizar algún componente, generando un error en pantalla y consola por no encontrar el `regeneratorRuntime`
![image](https://github.com/user-attachments/assets/58273856-4925-4315-9f1c-21590341f8ee)


**Descripción de la solución**
- Se modificó el plugin para que reciba archivos jsx y el `plugin` `babel-plugin-transform-react-remove-prop-types `que elimina los `PropTypes`  para reducir el tamaño del `bundle`  se ejecuta solo en producción ya que React no realiza esta validación en producción por defecto. El propósito de los `PropTypes` es facilitar el desarrollo y ayudar a identificar errores durante el proceso de desarrollo.

**¿Cómo se puede probar?**

Esto pasaba en repos mas nuevos, en beta no funciona mal, para probarlo se puede crear un repo de vite nuevo, sino deje para clonar un repo

**Para probarlo **
correr en una carpeta los comandos
- `git clone https://github.com/dgiannico19/test-Js.git`
-  `cd test-Js`
- `npm i
`- `npm run dev`

El repo tiene instalada la ultima versión de ui-web, y en `App.jsx`, se está utilizando el `Button`, por lo que al abrirse van a notar que no permite ver nada y en consola arroja un error

- Iniciando el proyecto `UI-WEB` en la rama actual
- Borrar `node_modules` en caso de tenerlos
- Correr comando `yarn`
- Luego correr comando `yarn build`
- Y para finalizar correr el comando `yalc publish`

Luego ingresamos al repo que deje de prueba

- Borrar `node_modules` en caso de tenerlos
- Correr el comando `yalc add @janiscommerce/ui-web`
- Correr comando `npm i`
- `npm run dev`
Ahora debería verse el botón y cualquier componente que quiera testear
![image](https://github.com/user-attachments/assets/0da19b22-c989-4d36-9547-188df3d0187a)

Luego ingresamos a Views o al repo que deje de prueba

- Ingresar a `beta` o `master` (es solo para probar)
- Bajar el docker
- Borrar node_modules en caso de tenerlos
- Correr el comando yalc add @janiscommerce/ui-web
- Correr comando npm i
- Levantar el docker 


**Screenshot**
![image](https://github.com/user-attachments/assets/ad41b5ed-8f0d-433b-bd38-6fd7b4e6967b)
![image](https://github.com/user-attachments/assets/90119281-d121-47e4-b9f0-250f33b1ea74)
