### PR TITLE
JMV-3709-mapa-pierde-centro-al-recargar

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -30,7 +30,7 @@ const Map = ({
 
 	const validMarkersExist = Array.isArray(markers) && markers.length;
 
-	const defaultMapCenter = { center: { lat: 0, lng: 0 }, zoom };
+	const defaultMapCenter = { lat: 0, lng: 0 };
 
 	const handlePositions = (key, value) => {
 		setControlsPositions((prev) => ({ ...prev, [key]: value }));
@@ -42,7 +42,7 @@ const Map = ({
 		if (!map) return;
 		mapRef.current = map;
 
-		map.setOptions({
+		mapRef.current.setOptions({
 			gestureHandling: 'greedy'
 		});
 
@@ -50,19 +50,21 @@ const Map = ({
 		handlePositions('fullScreen', window.google.maps.ControlPosition[fullScreenPos]);
 		handlePositions('zoom', window.google.maps.ControlPosition.RIGHT_BOTTOM);
 
-		if (!markers?.length) return map.setCenter(getCenterByGeolocationOrCenter(center));
+		if (!markers?.length)
+			mapRef.current.setCenter(getCenterByGeolocationOrCenter(center || defaultMapCenter));
 
-		map.fitBounds(getBoundsFromMarkers(markers));
+		if (markers?.length) mapRef.current.fitBounds(getBoundsFromMarkers(markers));
 		mapRef.current.setZoom(zoom);
 	}, []);
 
-	return isLoaded ? (
+	if (!isLoaded) return null;
+
+	return (
 		<GoogleMap
 			className="google-map-component"
 			onLoad={onLoad}
 			mapContainerStyle={{ height, width }}
 			options={mapOptions}
-			{...defaultMapCenter}
 		>
 			<>
 				{showSearchBar && <SearchBox className="google-map-component__search-box" />}
@@ -77,8 +79,6 @@ const Map = ({
 				)}
 			</>
 		</GoogleMap>
-	) : (
-		<></>
 	);
 };
 

--- a/src/components/Map/utils/getCenterByGeolocationOrCenter.js
+++ b/src/components/Map/utils/getCenterByGeolocationOrCenter.js
@@ -7,6 +7,6 @@ import { getGeolocationCoordinates, validateCoordinates } from './';
  * @param {number} center.lng The longitude value of the default center.
  */
 export default (center = {}) => {
-	if (validateCoordinates(center)) return { lat: center.lat, lng: center.lng };
+	if (validateCoordinates(center)) return center;
 	return getGeolocationCoordinates();
 };


### PR DESCRIPTION
### Link al ticket

https://janiscommerce.atlassian.net/browse/JMV-3709

### Descripción del requerimiento

Al momento de crear las rutas de la simulacion, esta sucediendo que el mapa cambia su centrado y no hay un feedback claro que se esta haciendo una request y esperando un resultado.

### Criterios de aprobacion

Que el mapa no pierda el centro si el usuario interactúa con el mismo o con alguna otra parte de la vista

### Descripción de la solución

En el componente mapa:

- se modificó la variable `defaultMapCenter` para que sea un objeto que sólo tenga coords
- ahora se utiliza el mapRef.current para usar los metodos de map ya que map se está guardando en el ref
- se eliminó el retorno donde se usa el método setCenter para que siga el flujo
- se agregó una validación en el método fitBounds para que sólo se ejecute si hay markers
- se modificó el primer retorno de la función getCenterByGeolocationOrCenter ya que era redundante lo que devolvía

### Cómo se puede probar?

Levantar la rama y correr el comando yarn storybook
Ir hacia el componente mapa (pedir la api key de google por privado)
Usar la interfaz de storybook para cambiar las props
Revisar que el centro del mapa no cambie

### Changelog

- **ADD**: fitBounds method validation by markers
- **CHANGE**: defaultMapCenter variable, isLoaded render validation, getCenterByGeolocationOrCenter function