### PR TITLE
add drag and drop controller to markers to manage it from wherever it…

### DIFF
--- a/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Marker from './components/Marker';
 
-const Markers = ({ readOnly = false, setMarker = () => {}, markers = [] }) => {
+const Markers = ({ readOnly = true, setMarker = () => {}, markers = [] }) => {
 	if (!markers.length) return null;
 
 	return (

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -4,13 +4,7 @@ import { debounce } from 'utils';
 import PropTypes from 'prop-types';
 import InfoWindow from './components/InfoWindow';
 
-const Marker = ({
-	markerData,
-	readOnly,
-	setMarkerCallback = () => {},
-	markerIdx,
-	markerProps: schemaMarkerProps
-}) => {
+const Marker = ({ markerData, readOnly, markerProps: schemaMarkerProps }) => {
 	const { onClick } = schemaMarkerProps || {};
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
@@ -23,18 +17,15 @@ const Marker = ({
 		if (!mouseOverInfoWindow) closeInfoWindow();
 	}, 100);
 
-	const markerHandles = {
-		...(onClick && { onClick: () => onClick(markerData) }),
-		onMouseOver: () => openInfoWindow(),
-		onMouseOut: () => delayedInfoWindowHover()
-	};
-
 	const markerProps = {
 		position: markerData.position,
-		draggable: !readOnly,
-		onDragEnd: ({ latLng }) => setMarkerCallback(latLng, markerIdx, markerData),
-		...(true && { ...markerHandles }),
-		icon: markerData.icon
+		draggable: markerData.isDraggable || !readOnly,
+		icon: markerData.icon,
+		onDragEnd: markerData.dragEnd,
+		onDragStart: markerData.dragStart,
+		onMouseOver: () => openInfoWindow(),
+		onMouseOut: () => delayedInfoWindowHover(),
+		...(onClick && { onClick: () => onClick(markerData) })
 	};
 
 	const infoWindowHandles = {
@@ -81,7 +72,10 @@ Marker.propTypes = {
 		overlay: PropTypes.element,
 		icon: PropTypes.shape({}),
 		infoWindowChildren: PropTypes.shape({}),
-		position: PropTypes.shape({})
+		position: PropTypes.shape({}),
+		isDraggable: PropTypes.bool,
+		dragEnd: PropTypes.func,
+		dragStart: PropTypes.func
 	}),
 	readOnly: PropTypes.bool,
 	setMarkerCallback: PropTypes.func,

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -21,8 +21,8 @@ const Marker = ({ markerData, readOnly, markerProps: schemaMarkerProps }) => {
 		position: markerData.position,
 		draggable: markerData.isDraggable || !readOnly,
 		icon: markerData.icon,
-		onDragEnd: markerData.dragEnd,
-		onDragStart: markerData.dragStart,
+		onDragEnd: markerData.onDragEnd,
+		onDragStart: markerData.onDragStart,
 		onMouseOver: () => openInfoWindow(),
 		onMouseOut: () => delayedInfoWindowHover(),
 		...(onClick && { onClick: () => onClick(markerData) })
@@ -74,8 +74,8 @@ Marker.propTypes = {
 		infoWindowChildren: PropTypes.shape({}),
 		position: PropTypes.shape({}),
 		isDraggable: PropTypes.bool,
-		dragEnd: PropTypes.func,
-		dragStart: PropTypes.func
+		onDragEnd: PropTypes.func,
+		onDragStart: PropTypes.func
 	}),
 	readOnly: PropTypes.bool,
 	setMarkerCallback: PropTypes.func,

--- a/src/components/Map/components/MarkersDrawer/components/Route/Route.js
+++ b/src/components/Map/components/MarkersDrawer/components/Route/Route.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Polyline } from '@react-google-maps/api';
 import Markers from '../Markers';
 
-const Route = ({ routeData = {}, readOnly = false, setMarker = () => {} }) => {
+const Route = ({ routeData = {}, readOnly = true, setMarker = () => {} }) => {
 	const { polylines = [] } = routeData;
 	return (
 		<>


### PR DESCRIPTION
**Link al ticket**
- https://janiscommerce.atlassian.net/browse/JMV-3737

**Descripción del requerimiento**
- Se necesita aplicar los cambios del mapa en ui-web, para poder controlar el drag and drop del mapa desde donde lo utilicemos

Se deberá cambiar el valor de la prop `draggable` del componente `Marker` de `!readOnly` a `markerData.isDraggable || !readOnly
`
Se deben agregar los `callbacks` de `drag and drop` en el `marker` para que tenga acceso el lugar donde lo usamos

Ambos valores se van a manejar desde `markerData`
**Criterios de aprobacion**
- Si llega la prop `isDraggable` de `markerData`, toma su valor, si no toma el valor del `readOnly` de las `options` del mapa (default es true, significa que no es `draggable`)
- Si el `marker` recibe callbacks `onDragEnd` o `onDragStart` debe funcionar al momento de `draggear` los marcadores

**Descripción de la solución**
- Se agregó la validación para que tome prioridad el valor de `isDraggable` del marcador
- Se agregaron las funciones `onDragEnd` y `onDragStart` para que funcionen si el marcador las recibe
Todo se maneja desde `markerData`

También se cambió el valor por default de la prop `readOnly` que en mapa era true y en marcadores y rutas era false, para que coincidan todos con el default true.

**Cómo se puede probar?**

**Para probarlo en Storybook**
- Levantar la rama y correr el comando `yarn storybook`
- pegarle el apikey en `Map/Map.stories.js`
- Ingresar en [Map](http://localhost:6006/?path=/story/components-map--hidden-info)

**Para probarlo en Views**
Iniciando el proyecto **UI-WEB** en la rama actual
Borrar `node_modules` en caso de tenerlos
Correr comando `yarn`
Luego correr comando `yarn build`
Y para finalizar correr el comando `yalc publish`
Luego ingresamos a `Views` puede hacerse sobre beta, sino

Ingresar a alguna rama como `JMV-3669-deploy`
Bajar el `docker`
Borrar `node_modules` en caso de tenerlos
Correr el comando `yalc add @janiscommerce/ui-web`
Correr comando `npm i`
Levantar el `docker`

Para agregarle el `drag and drop` desde `Views`, 
Agregar `isDraggable` en la función que formatea los `shippings` sin ruta
En `src/libs/delivery/RoutePlanning/index.js`

**Changelog**
- Added: drag and drop controller at marker