### PR TITLE
Added destructuring of marker to get onClick function

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -13,6 +13,7 @@ const Map = ({
 	center = DEFAULT_CENTER,
 	zoom = 13,
 	markers = [],
+	markerOptions = {},
 	options = {},
 	callbackOnSuccessDirections = () => {},
 	callbackOnErrorDirections = () => {},
@@ -78,6 +79,7 @@ const Map = ({
 			{validMarkersExist && (
 				<MarkersDrawer
 					markers={markers}
+					markerOptions={markerOptions}
 					readOnly={mapOptions.readOnly}
 					callbackOnSuccessDirections={callbackOnSuccessDirections}
 					callbackOnErrorDirections={callbackOnErrorDirections}
@@ -118,6 +120,8 @@ Map.propTypes = {
 			})
 		})
 	),
+	/** Extra config for each marker */
+	markerOptions: PropTypes.shape({}),
 	/** Prevents markers from being moved */
 	/** Config to customize map */
 	options: PropTypes.shape({}),

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -361,6 +361,7 @@ const markersMockMultiRutas = [
 		},
 		points: [
 			{
+				onClick: () => console.log('marker 1'),
 				position: { lng: -58.43, lat: -34.5986 },
 				icon: {
 					url: `data:image/svg+xml;utf-8, 		<svg width="72"

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -1971,6 +1971,15 @@ const Template = (args) => <Map {...args} />;
 const baseArgs = {
 	center,
 	markers: markersMockMultiRutas,
+	options: {
+		readOnly: false
+	},
+	markerOptions: {
+		onClick: ({ position }) => {
+			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
+		},
+		onDragEnd: (_, { latLng: { lat, lng } }) => alert(`New position: ${lat()}, ${lng()}`)
+	},
 	googleMapsApiKey: ''
 };
 export const OnlyMap = Template.bind({});
@@ -2015,12 +2024,5 @@ HiddenInfo.args = {
 };
 
 WithOnClick.args = {
-	...baseArgs,
-	markers: baseArgs.markers.map((marker, routeIdx) => ({
-		...marker,
-		points: marker.points.map((point, idx) => ({
-			...point,
-			onClick: () => alert(`Clicked on marker with id: ${routeIdx} - ${idx}`)
-		}))
-	}))
+	...baseArgs
 };

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -361,7 +361,6 @@ const markersMockMultiRutas = [
 		},
 		points: [
 			{
-				onClick: (args) => console.log('marker 1', args),
 				position: { lng: -58.43, lat: -34.5986 },
 				icon: {
 					url: `data:image/svg+xml;utf-8, 		<svg width="72"
@@ -984,6 +983,7 @@ const markersMockMultiRutas = [
 		},
 		points: [
 			{
+				onClick: (args) => console.log('marker 1', args),
 				position: { lat: -34.6064, lng: -58.4371 },
 				icon: {
 					url: `data:image/svg+xml;utf-8, 		<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -361,7 +361,7 @@ const markersMockMultiRutas = [
 		},
 		points: [
 			{
-				onClick: () => console.log('marker 1'),
+				onClick: (args) => console.log('marker 1', args),
 				position: { lng: -58.43, lat: -34.5986 },
 				icon: {
 					url: `data:image/svg+xml;utf-8, 		<svg width="72"

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -983,7 +983,6 @@ const markersMockMultiRutas = [
 		},
 		points: [
 			{
-				onClick: (args) => console.log('marker 1', args),
 				position: { lat: -34.6064, lng: -58.4371 },
 				icon: {
 					url: `data:image/svg+xml;utf-8, 		<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -1976,6 +1975,7 @@ const baseArgs = {
 };
 export const OnlyMap = Template.bind({});
 export const HiddenInfo = Template.bind({});
+export const WithOnClick = Template.bind({});
 
 OnlyMap.args = {
 	...baseArgs
@@ -2012,4 +2012,15 @@ HiddenInfo.args = {
 			}
 		]
 	}
+};
+
+WithOnClick.args = {
+	...baseArgs,
+	markers: baseArgs.markers.map((marker, routeIdx) => ({
+		...marker,
+		points: marker.points.map((point, idx) => ({
+			...point,
+			onClick: () => alert(`Clicked on marker with id: ${routeIdx} - ${idx}`)
+		}))
+	}))
 };

--- a/src/components/Map/components/MarkersDrawer/MarkersDrawer.js
+++ b/src/components/Map/components/MarkersDrawer/MarkersDrawer.js
@@ -5,13 +5,13 @@ import Route from './components/Route';
 
 const MarkersDrawer = ({
 	markers = [],
+	markerOptions = {},
 	readOnly = true,
-	setMarker = () => {},
 	callbackOnSuccessDirections = () => {},
 	callbackOnErrorDirections = () => {},
 	googleMapsApiKey = ''
 }) => {
-	const commonProps = { readOnly, setMarker };
+	const commonProps = { readOnly };
 	return (
 		<>
 			{markers.map((marker, idx) =>
@@ -20,12 +20,18 @@ const MarkersDrawer = ({
 						key={`${idx.toString()}`}
 						{...commonProps}
 						routeData={marker}
+						markerOptions={markerOptions}
 						callbackOnSuccessDirections={callbackOnSuccessDirections}
 						callbackOnErrorDirections={callbackOnErrorDirections}
 						googleMapsApiKey={googleMapsApiKey}
 					/>
 				) : (
-					<Markers key={`${idx.toString()}`} {...commonProps} markers={marker.points} />
+					<Markers
+						key={`${idx.toString()}`}
+						{...commonProps}
+						markers={marker.points}
+						markerOptions={markerOptions}
+					/>
 				)
 			)}
 		</>
@@ -51,8 +57,8 @@ MarkersDrawer.propTypes = {
 			})
 		})
 	),
+	markerOptions: PropTypes.shape({}),
 	readOnly: PropTypes.bool,
-	setMarker: PropTypes.func,
 	callbackOnSuccessDirections: PropTypes.func,
 	callbackOnErrorDirections: PropTypes.func,
 	googleMapsApiKey: PropTypes.string

--- a/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Marker from './components/Marker';
 
-const Markers = ({ readOnly = false, setMarker = () => {}, markers = [] }) => {
+const Markers = ({ readOnly = true, setMarker = () => {}, markers = [] }) => {
 	if (!markers.length) return null;
 
 	return (

--- a/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Marker from './components/Marker';
 
-const Markers = ({ readOnly = true, setMarker = () => {}, markers = [] }) => {
+const Markers = ({ readOnly = true, markers = [], markerOptions = {} }) => {
 	if (!markers.length) return null;
 
 	return (
@@ -10,10 +10,10 @@ const Markers = ({ readOnly = true, setMarker = () => {}, markers = [] }) => {
 			{markers.map((marker, idx) => (
 				<Marker
 					markerData={{ ...marker }}
+					markerOptions={markerOptions}
 					key={idx}
 					readOnly={readOnly}
 					markerIdx={idx}
-					setMarkerCallback={setMarker}
 				/>
 			))}
 		</>
@@ -22,8 +22,8 @@ const Markers = ({ readOnly = true, setMarker = () => {}, markers = [] }) => {
 
 Markers.propTypes = {
 	markers: PropTypes.arrayOf(PropTypes.shape({})),
-	readOnly: PropTypes.bool,
-	setMarker: PropTypes.func
+	markerOptions: PropTypes.shape({}),
+	readOnly: PropTypes.bool
 };
 
 export default Markers;

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -4,8 +4,17 @@ import { debounce } from 'utils';
 import PropTypes from 'prop-types';
 import InfoWindow from './components/InfoWindow';
 
-const Marker = ({ markerData, readOnly, setMarkerCallback = () => {}, markerIdx }) => {
-	const { onClick, icon, position, overlay, infoWindowChildren } = markerData || {};
+const Marker = ({ markerData, readOnly }) => {
+	const {
+		onClick,
+		icon,
+		position,
+		overlay,
+		infoWindowChildren,
+		isDraggable,
+		onDragEnd,
+		onDragStart
+	} = markerData || {};
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 	const [mouseOverInfoWindow, setMouseOverInfoWindow] = useState(false);
@@ -17,18 +26,15 @@ const Marker = ({ markerData, readOnly, setMarkerCallback = () => {}, markerIdx 
 		if (!mouseOverInfoWindow) closeInfoWindow();
 	}, 100);
 
-	const markerHandles = {
-		...(onClick && { onClick: () => onClick(markerData) }),
-		onMouseOver: () => openInfoWindow(),
-		onMouseOut: () => delayedInfoWindowHover()
-	};
-
 	const markerProps = {
-		position: position,
-		draggable: !readOnly,
-		onDragEnd: ({ latLng }) => setMarkerCallback(latLng, markerIdx, markerData),
-		...(true && { ...markerHandles }),
-		icon: icon
+		position,
+		draggable: isDraggable || !readOnly,
+		icon,
+		onDragEnd: ({ latLng }) => onDragEnd(latLng, markerData),
+		onDragStart: ({ latLng }) => onDragStart(latLng, markerData),
+		onMouseOver: () => openInfoWindow(),
+		onMouseOut: () => delayedInfoWindowHover(),
+		...(onClick && { onClick: () => onClick(markerData) })
 	};
 
 	const infoWindowHandles = {
@@ -75,10 +81,13 @@ Marker.propTypes = {
 		overlay: PropTypes.element,
 		icon: PropTypes.shape({}),
 		infoWindowChildren: PropTypes.shape({}),
-		position: PropTypes.shape({})
+		position: PropTypes.shape({}),
+		isDraggable: PropTypes.bool,
+		onDragEnd: PropTypes.func,
+		onDragStart: PropTypes.func,
+		onClick: PropTypes.func
 	}),
 	readOnly: PropTypes.bool,
-	setMarkerCallback: PropTypes.func,
 	markerIdx: PropTypes.number,
 	markerProps: PropTypes.shape({}),
 	children: PropTypes.element

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -4,17 +4,10 @@ import { debounce } from 'utils';
 import PropTypes from 'prop-types';
 import InfoWindow from './components/InfoWindow';
 
-const Marker = ({ markerData, readOnly }) => {
-	const {
-		icon,
-		position,
-		overlay,
-		infoWindowChildren,
-		isDraggable,
-		onClick = () => {},
-		onDragEnd = () => {},
-		onDragStart = () => {}
-	} = markerData || {};
+const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
+	const { icon, position, overlay, infoWindowChildren, isDraggable } = markerData || {};
+
+	const { onClick = () => {}, onDragStart = () => {}, onDragEnd = () => {} } = markerOptions;
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 	const [mouseOverInfoWindow, setMouseOverInfoWindow] = useState(false);
@@ -30,9 +23,9 @@ const Marker = ({ markerData, readOnly }) => {
 		position,
 		draggable: isDraggable || !readOnly,
 		icon,
-		onClick: () => onClick(markerData),
-		onDragEnd: ({ latLng }) => onDragEnd(latLng, markerData),
-		onDragStart: ({ latLng }) => onDragStart(latLng, markerData),
+		onClick: (eventData) => onClick(markerData, eventData),
+		onDragEnd: (eventData) => onDragEnd(markerData, eventData),
+		onDragStart: (eventData) => onDragStart(markerData, eventData),
 		onMouseOver: () => openInfoWindow(),
 		onMouseOut: () => delayedInfoWindowHover()
 	};
@@ -87,6 +80,7 @@ Marker.propTypes = {
 		onDragStart: PropTypes.func,
 		onClick: PropTypes.func
 	}),
+	markerOptions: PropTypes.shape({}),
 	readOnly: PropTypes.bool,
 	markerIdx: PropTypes.number,
 	markerProps: PropTypes.shape({}),

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -4,14 +4,8 @@ import { debounce } from 'utils';
 import PropTypes from 'prop-types';
 import InfoWindow from './components/InfoWindow';
 
-const Marker = ({
-	markerData,
-	readOnly,
-	setMarkerCallback = () => {},
-	markerIdx,
-	markerProps: schemaMarkerProps
-}) => {
-	const { onClick } = schemaMarkerProps || {};
+const Marker = ({ markerData, readOnly, setMarkerCallback = () => {}, markerIdx }) => {
+	const { onClick, icon, position, overlay, infoWindowChildren } = markerData || {};
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 	const [mouseOverInfoWindow, setMouseOverInfoWindow] = useState(false);
@@ -30,11 +24,11 @@ const Marker = ({
 	};
 
 	const markerProps = {
-		position: markerData.position,
+		position: position,
 		draggable: !readOnly,
 		onDragEnd: ({ latLng }) => setMarkerCallback(latLng, markerIdx, markerData),
 		...(true && { ...markerHandles }),
-		icon: markerData.icon
+		icon: icon
 	};
 
 	const infoWindowHandles = {
@@ -53,23 +47,23 @@ const Marker = ({
 	return (
 		<>
 			<MarkerComponent {...markerProps} />
-			{markerData.overlay && (
+			{overlay && (
 				<OverlayView
 					className="google-map-component__overlay-view"
-					position={markerData.position}
+					position={position}
 					mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
 					getPixelPositionOffset={(width) => getPixelPositionOffset(width)}
 				>
-					{markerData.overlay()}
+					{overlay()}
 				</OverlayView>
 			)}
-			{infoWindowOpen && markerData.infoWindowChildren && (
+			{infoWindowOpen && infoWindowChildren && (
 				<InfoWindow
 					className="google-map-component__info-window"
-					data={markerData.position}
+					data={position}
 					infoWindowHandles={infoWindowHandles}
 				>
-					{markerData.infoWindowChildren()}
+					{infoWindowChildren()}
 				</InfoWindow>
 			)}
 		</>

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -6,14 +6,14 @@ import InfoWindow from './components/InfoWindow';
 
 const Marker = ({ markerData, readOnly }) => {
 	const {
-		onClick,
 		icon,
 		position,
 		overlay,
 		infoWindowChildren,
 		isDraggable,
-		onDragEnd,
-		onDragStart
+		onClick = () => {},
+		onDragEnd = () => {},
+		onDragStart = () => {}
 	} = markerData || {};
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
@@ -30,11 +30,11 @@ const Marker = ({ markerData, readOnly }) => {
 		position,
 		draggable: isDraggable || !readOnly,
 		icon,
+		onClick: () => onClick(markerData),
 		onDragEnd: ({ latLng }) => onDragEnd(latLng, markerData),
 		onDragStart: ({ latLng }) => onDragStart(latLng, markerData),
 		onMouseOver: () => openInfoWindow(),
-		onMouseOut: () => delayedInfoWindowHover(),
-		...(onClick && { onClick: () => onClick(markerData) })
+		onMouseOut: () => delayedInfoWindowHover()
 	};
 
 	const infoWindowHandles = {
@@ -93,4 +93,4 @@ Marker.propTypes = {
 	children: PropTypes.element
 };
 
-export default Marker;
+export default React.memo(Marker);

--- a/src/components/Map/components/MarkersDrawer/components/Route/Route.js
+++ b/src/components/Map/components/MarkersDrawer/components/Route/Route.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { Polyline } from '@react-google-maps/api';
 import Markers from '../Markers';
 
-const Route = ({ routeData = {}, readOnly = true, setMarker = () => {} }) => {
+const Route = ({ routeData = {}, markerOptions = {}, readOnly = true }) => {
 	const { polylines = [] } = routeData;
 	return (
 		<>
-			<Markers readOnly={readOnly} setMarker={setMarker} markers={routeData.points} />
+			<Markers readOnly={readOnly} markers={routeData.points} markerOptions={markerOptions} />
 			<Polyline path={polylines} options={routeData.polylineOptions} />
 		</>
 	);
@@ -27,8 +27,8 @@ Route.propTypes = {
 			strokeWeight: PropTypes.number
 		})
 	}),
-	readOnly: PropTypes.bool,
-	setMarker: PropTypes.func
+	markerOptions: PropTypes.shape({}),
+	readOnly: PropTypes.bool
 };
 
 export default Route;

--- a/src/components/Map/components/MarkersDrawer/components/Route/Route.js
+++ b/src/components/Map/components/MarkersDrawer/components/Route/Route.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Polyline } from '@react-google-maps/api';
 import Markers from '../Markers';
 
-const Route = ({ routeData = {}, readOnly = false, setMarker = () => {} }) => {
+const Route = ({ routeData = {}, readOnly = true, setMarker = () => {} }) => {
 	const { polylines = [] } = routeData;
 	return (
 		<>


### PR DESCRIPTION
**Link al ticket**
- https://janiscommerce.atlassian.net/browse/JMV-3725

**Descripción del requerimiento**
- Se necesita poder utilizar el onClick que se declare en cada marcador
- Se necesita aplicar los cambios del mapa en ui-web, para poder controlar el drag and drop del mapa desde donde lo utilicemos
Se deberá cambiar el valor de la prop draggable del componente Marker de !readOnly a markerData.isDraggable || !readOnly 
Se deben agregar los callbacks de drag and drop en el marker para que tenga acceso el lugar donde lo usamos

Ambos valores se van a manejar desde markerData
**Criterios de aprobacion**
- Al pasarle la key onClick con una funcion a un marcador y hacer click en este debe ejecutarse la funcion recibiendo como argumento la info de todo el marcador
- Si llega la prop isDraggable de markerData, toma su valor, si no toma el valor del readOnly de las options del mapa (default es true, significa que no es draggable)
- Si el marker recibe callbacks onDragEnd o onDragStart debe funcionar al momento de draggear los marcadores

**Descripción de la solución**
- Se cambio la obtencion de onClick de schemaMarkerProps a markerData ya que no se esta usando markerProps
- Aprovechando esto se cambiaron varias props que se leen de markerData para destructurarlas en un solo lugar
- Se agregó la validación para que tome prioridad el valor de isDraggable del marcador
- Se agregó la prop `markerOptions` que debe declararse en el componente `Map`, esta sirve para que el componente `Marker` reciba los callbacks `onClick`, `onDragEnd` y `onDragStart` para que funcionen si el marcador las recibe pasandole la data que devuelve el handler y la data del marcador que es útil al ejecutar la función desde afuera
- Se cambió el valor por default de la prop readOnly que en mapa era true y en marcadores y rutas era false, para que coincidan todos con el default true.
- Se eliminó la función setMarker ya que no se estaba usando en ningún lado

**Cómo se puede probar?**

**Para probarlo en Storybook**
- Levantar la rama y correr el comando `yarn storybook`
- pegarle el apikey en `Map/Map.stories.js`
- Ingresar en [Map](http://localhost:6006/?path=/story/components-map--hidden-info)
- Hacer click en el marcador 1 de la ruta magenta
- Debe verse el console log con la data del marcador en la consola del navegador

**Para probarlo en Views**
Iniciando el proyecto **UI-WEB** en la rama actual
Borrar `node_modules` en caso de tenerlos
Correr comando `yarn`
Luego correr comando `yarn build`
Y para finalizar correr el comando `yalc publish`
Luego ingresamos a `Views` puede hacerse sobre beta, sino

Ingresar a alguna rama como `JMV-3669-deploy`
Bajar el `docker`
Borrar `node_modules` en caso de tenerlos
Correr el comando `yalc add @janiscommerce/ui-web`
Correr comando `npm i`
Levantar el `docker`

Para agregarle el `onClick` desde `Views`, 
Agregar `onClick` en la función _formatStopsToDirections en `src/libs/delivery/RoutePlanning/index.js` y pasarle alguna funcion por ejemplo un console.log
Al ir a la vista y clickear cualquier marcador debe mostrarse el log en la consola

Para agregarle el drag and drop desde Views,
Agregar isDraggable en la función que formatea los shippings sin ruta
En src/libs/delivery/RoutePlanning/index.js


**Changelog**
- Added: onClick function at marker
- Added: drag and drop controller at marker