### PR TITLE
Improved memo function on Marker

### DIFF
--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -87,4 +87,11 @@ Marker.propTypes = {
 	children: PropTypes.element
 };
 
-export default React.memo(Marker);
+export default React.memo(Marker, (prev, next) => {
+	return (
+		prev.markerData.position.lat === next.markerData.position.lat &&
+		prev.markerData.position.lng === next.markerData.position.lng &&
+		prev.markerData.icon.url === next.markerData.icon.url &&
+		prev.readOnly === next.readOnly
+	);
+});

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -88,10 +88,7 @@ Marker.propTypes = {
 };
 
 export default React.memo(Marker, (prev, next) => {
-	return (
-		prev.markerData.position.lat === next.markerData.position.lat &&
-		prev.markerData.position.lng === next.markerData.position.lng &&
-		prev.markerData.icon.url === next.markerData.icon.url &&
-		prev.readOnly === next.readOnly
-	);
+	const serializedPrev = JSON.stringify(prev);
+	const serializedNext = JSON.stringify(next);
+	return serializedPrev === serializedNext;
 });


### PR DESCRIPTION
**Link al ticket**
- https://janiscommerce.atlassian.net/browse/JMV-3725

**Descripción del requerimiento**
- Se necesite que marker se memoize para evitar re-renderings innecesarios

Ambos valores se van a manejar desde markerData
**Criterios de aprobacion**
- Al actualizar la prop markers solo debe renderizarse el marcador que haya recibido cambios

**Descripción de la solución**
- Se agrego una funcion que compara las propiedades previas y actuales de marker serializandolas para que detecte los cambios correctamente, antes no funcionaba porque estaba comparando objetos y sus referencias cambian asi que opte por comparar los valores directamente

**Cómo se puede probar?**

**Para probarlo en Storybook**
- Ir al componente Marker y dentro de la funcion de memo agregar un console log para detectar cuando cambia o no un valor
``
console.log({prev, next}, 	JSON.stringify(next) === JSON.stringify(prev));
``
Tambien agregar un console.log('render') antes del return de Marker para ver cuantas veces se renderiza

- Levantar la rama y correr el comando `yarn storybook`
- pegarle el apikey en `Map/Map.stories.js`
- Ingresar en [Map](http://localhost:6006/?path=/story/components-map--hidden-info)
- Desde controls ir a markers y cambiar la posicion y/o un icono y ver que salga false solo en el marcador modificado, esto significa que es ese marcador de volvera a renderizar, el console render debera salir 15 veces 1 por cada marcador, anteriormente salian 15 luego unas advertencias y luego otros 15, asi que si esta renderizando menos


**Para probarlo en Views**
Mantener los console.log en ui-web 
Iniciando el proyecto **UI-WEB** en la rama actual
Borrar `node_modules` en caso de tenerlos
Correr comando `yarn`
Luego correr comando `yarn build`
Y para finalizar correr el comando `yalc publish`
Luego ingresamos a `Views` puede hacerse sobre beta, sino

Ingresar a `git checkout JMV-3725-optimization-button-implementation`
Bajar el `docker`
Borrar `node_modules` en caso de tenerlos
Correr el comando `yalc add @janiscommerce/ui-web`
Correr comando `npm i`
Levantar el `docker`

Acceder a http://janis.localhost:3001/tms/route-planning/edit/67eb26402d28bc67e3c9ab8f y al abrir el modal de optimizacion clickear los marcadores y ver que cambie de color
En la consola deberan verse 2 false lo que significa que solo esos 2 markers se renderizaran
Tambien el console render debera hacerse solo 2 veces, tener en cuenta que al hacer hover tambien se muestra el console render


**Changelog**
- Changed: memo function on marker