### PR TITLE
JMV-3730-reordenar-agregar-stops-ruta-desde-mapa

### DIFF
--- a/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/Markers.js
@@ -11,7 +11,7 @@ const Markers = ({ readOnly = true, markers = [], markerOptions = {} }) => {
 				<Marker
 					markerData={{ ...marker }}
 					markerOptions={markerOptions}
-					key={idx}
+					key={`${idx.toString()}-${marker?.position?.lat}-${marker?.position?.lng}`}
 					readOnly={readOnly}
 					markerIdx={idx}
 				/>

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -7,7 +7,12 @@ import InfoWindow from './components/InfoWindow';
 const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 	const { icon, position, overlay, infoWindowChildren, isDraggable } = markerData || {};
 
-	const { onClick = () => {}, onDragStart = () => {}, onDragEnd = () => {} } = markerOptions;
+	const {
+		onLoad = () => {},
+		onClick = () => {},
+		onDragStart = () => {},
+		onDragEnd = () => {}
+	} = markerOptions;
 
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 	const [mouseOverInfoWindow, setMouseOverInfoWindow] = useState(false);
@@ -23,6 +28,7 @@ const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 		position,
 		draggable: isDraggable || !readOnly,
 		icon,
+		onLoad: (markerInstance) => onLoad(markerData, markerInstance),
 		onClick: (eventData) => onClick(markerData, eventData),
 		onDragEnd: (eventData) => onDragEnd(markerData, eventData),
 		onDragStart: (eventData) => onDragStart(markerData, eventData),


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3730

## Descripción del requerimiento
Se necesita agregar el callback onLoad para que se ejecute por cada Marker

## Descripción de la solución
Se modificó la prop `key` de cada componente Marker al mapear los marcadores para que sea distinto y se force un nuevo render
Se agregó el callback onLoad dentro del componente Marker para poder utilizarlo por fuera

## Cómo se puede probar?
Ingresar a la rama
Levantar el proyecto con `yarn storybook`
En Map.stories.js, dentro de baseArgs.markerOptions, agregar el callback `onLoad` para probar la función, el mismo debe ejecutarse por cada marker que aparezca en el mapa

## Changelog
**ADDED**
- onLoad callback for Marker component

**CHANGED**
- marker key in markers mapping