### PR TITLE
JMV-3730-reordenar-agregar-stops-ruta-desde-mapa

### DIFF
--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -1979,10 +1979,6 @@ const baseArgs = {
 			const { position } = marker;
 			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
 		},
-		onDragStart: ({ marker }) => {
-			const { position } = marker;
-			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
-		},
 		onDragEnd: ({ marker }) => {
 			const { position } = marker;
 			alert(`New position: ${position?.lat}, ${position?.lng}`);

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -1968,27 +1968,61 @@ export default {
 
 const Template = (args) => <Map {...args} />;
 
+const WithMarkerOptionsTemplate = (args) => {
+	const changeHandlerInfo = (info) => {
+		document.querySelector('.eventHandlerInfo').textContent = info;
+	};
+
+	const onLoad = () => changeHandlerInfo('onLoad event');
+
+	const onClick = ({ marker }) => {
+		const { position } = marker;
+		changeHandlerInfo(
+			`onClick event | Clicked on marker at position ${position?.lat}, ${position?.lng}`
+		);
+	};
+
+	const onDragStart = ({ marker }) => {
+		const { position } = marker;
+		changeHandlerInfo(`onDragStart event | ${position}`);
+	};
+
+	const onDrag = (event = {}) => {
+		const {
+			latLng: { lat, lng }
+		} = event;
+		changeHandlerInfo(`onDrag event | ${lat()}, ${lng()}`);
+	};
+
+	const onDragEnd = ({ marker }) => {
+		const { position } = marker;
+		changeHandlerInfo(`onDragEnd event | New position: ${position?.lat}, ${position?.lng}`);
+	};
+
+	return (
+		<>
+			<Map {...args} markerOptions={{ onLoad, onClick, onDragStart, onDrag, onDragEnd }} />
+			<div
+				className="eventHandlerInfo"
+				style={{
+					marginTop: '30px',
+					padding: '20px 0',
+					textAlign: 'center',
+					borderTop: '1px solid grey'
+				}}
+			/>
+		</>
+	);
+};
+
 const baseArgs = {
 	center,
 	markers: markersMockMultiRutas,
-	options: {
-		readOnly: false
-	},
-	markerOptions: {
-		onClick: ({ marker }) => {
-			const { position } = marker;
-			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
-		},
-		onDragEnd: ({ marker }) => {
-			const { position } = marker;
-			alert(`New position: ${position?.lat}, ${position?.lng}`);
-		}
-	},
 	googleMapsApiKey: ''
 };
 export const OnlyMap = Template.bind({});
 export const HiddenInfo = Template.bind({});
-export const WithOnClick = Template.bind({});
+export const WithMarkerOptions = WithMarkerOptionsTemplate.bind({});
 
 OnlyMap.args = {
 	...baseArgs
@@ -2027,6 +2061,9 @@ HiddenInfo.args = {
 	}
 };
 
-WithOnClick.args = {
-	...baseArgs
+WithMarkerOptions.args = {
+	...baseArgs,
+	options: {
+		readOnly: false
+	}
 };

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -1975,10 +1975,18 @@ const baseArgs = {
 		readOnly: false
 	},
 	markerOptions: {
-		onClick: ({ position }) => {
+		onClick: ({ marker }) => {
+			const { position } = marker;
 			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
 		},
-		onDragEnd: (_, { latLng: { lat, lng } }) => alert(`New position: ${lat()}, ${lng()}`)
+		onDragStart: ({ marker }) => {
+			const { position } = marker;
+			alert(`Clicked on marker at position ${position?.lat}, ${position?.lng}`);
+		},
+		onDragEnd: ({ marker }) => {
+			const { position } = marker;
+			alert(`New position: ${position?.lat}, ${position?.lng}`);
+		}
 	},
 	googleMapsApiKey: ''
 };

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -42,7 +42,7 @@ const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 		const hasEqualLng = marker.lng === updatedMarkerCoords.lng;
 
 		return {
-			marker: hasEqualLat && hasEqualLng ? marker : updateMarker(updatedMarkerCoords),
+			marker: hasEqualLat && hasEqualLng ? marker : updateMarker({ position: updatedMarkerCoords }),
 			prevMarker: marker,
 			instance: markerRef.current?.marker
 		};

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Marker as MarkerComponent, OverlayView } from '@react-google-maps/api';
 import { debounce } from 'utils';
 import PropTypes from 'prop-types';
@@ -14,6 +14,8 @@ const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 		onDragEnd = () => {}
 	} = markerOptions;
 
+	const markerRef = useRef(null);
+
 	const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 	const [mouseOverInfoWindow, setMouseOverInfoWindow] = useState(false);
 
@@ -25,13 +27,14 @@ const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 	}, 100);
 
 	const markerProps = {
+		ref: markerRef,
 		position,
 		draggable: isDraggable || !readOnly,
 		icon,
 		onLoad: (markerInstance) => onLoad(markerData, markerInstance),
-		onClick: (eventData) => onClick(markerData, eventData),
-		onDragEnd: (eventData) => onDragEnd(markerData, eventData),
-		onDragStart: (eventData) => onDragStart(markerData, eventData),
+		onClick: (eventData) => onClick(markerData, eventData, markerRef.current?.marker),
+		onDragEnd: (eventData) => onDragEnd(markerData, eventData, markerRef.current?.marker),
+		onDragStart: (eventData) => onDragStart(markerData, eventData, markerRef.current?.marker),
 		onMouseOver: () => openInfoWindow(),
 		onMouseOut: () => delayedInfoWindowHover()
 	};

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/Marker.js
@@ -3,7 +3,7 @@ import { Marker as MarkerComponent, OverlayView } from '@react-google-maps/api';
 import { debounce } from 'utils';
 import PropTypes from 'prop-types';
 import InfoWindow from './components/InfoWindow';
-import { getCoordsFromEvent } from './utils';
+import { getCoordsFromEvent, markerHasEqualPosition } from './utils';
 
 const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 	const [marker, setMarker] = useState(markerData);
@@ -36,13 +36,12 @@ const Marker = ({ markerData = {}, markerOptions = {}, readOnly = true }) => {
 	};
 
 	const getEventHandlerData = (event) => {
-		const updatedMarkerCoords = getCoordsFromEvent(event);
-
-		const hasEqualLat = marker.lat === updatedMarkerCoords.lat;
-		const hasEqualLng = marker.lng === updatedMarkerCoords.lng;
+		const newPosition = getCoordsFromEvent(event);
 
 		return {
-			marker: hasEqualLat && hasEqualLng ? marker : updateMarker({ position: updatedMarkerCoords }),
+			marker: markerHasEqualPosition(marker?.position, newPosition)
+				? marker
+				: updateMarker({ position: newPosition }),
 			prevMarker: marker,
 			instance: markerRef.current?.marker
 		};

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/utils.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/utils.js
@@ -157,3 +157,9 @@ export const getCoordsFromEvent = (event = {}) => {
 	const { latLng: { lat = () => {}, lng = () => {} } = {} } = event;
 	return { lat: lat(), lng: lng() };
 };
+
+export const markerHasEqualPosition = (prevPosition = {}, newPosition = {}) => {
+	const hasEqualLat = prevPosition?.lat === newPosition?.lat;
+	const hasEqualLng = prevPosition?.lng === newPosition?.lng;
+	return hasEqualLat && hasEqualLng;
+};

--- a/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/utils.js
+++ b/src/components/Map/components/MarkersDrawer/components/Markers/components/Marker/utils.js
@@ -151,3 +151,9 @@ export const getSvgUrl = ({ color, icon, size, label, iconColor }, index) =>
 	icons[icon]
 		? getIconSvgTemplate({ color, icon, size, iconColor, index })
 		: getDefaultSvgTemplate(color, label);
+
+export const getCoordsFromEvent = (event = {}) => {
+	if (typeof event !== 'object') return;
+	const { latLng: { lat = () => {}, lng = () => {} } = {} } = event;
+	return { lat: lat(), lng: lng() };
+};


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3730

## Descripción del requerimiento
Se necesita tomar la instancia del marker de la librería de google-maps/api

## Descripción de la solución
- Se agregó un useRef para guardar la referencia de la instancia del marker, esta misma se pasa como parámetros a los handlers de los eventos del componente para poder usarla en los callbacks
- Se agregó el callback `onDrag` que se ejecuta en el handler `onDrag` del componente Marker de la librería, su evento pasa como parámetro al callback
- Se agregó el state `marker` para mantener el marcador actualizado cuando se ejecuta alguno de los handlers
- Se agregó la función `updateMarker` que actualiza la posición del marker
- Se agregó la util `getCoordsFromEvent` que extrae la lat y la lng del objeto latLng del evento y las devuelve
- Se agregó la función `getEventHandlerData` que trae las nuevas coordenadas, valida si las coordenadas anteriores y las nuevas son las mismas y retorna la data para usar en los callbacks
- Se agregó un componente nuevo en storybook llamado `WithMarkerOptionsTemplate`, este mismo se usa en `withMarkerOptions`, antes llamado `withOnClick`


## Cómo se puede probar?
Ingresar a la rama
Levantar el proyecto con `yarn storybook`
En Map.stories.js, dentro de baseArgs.markerOptions probar:
- agregando el nuevo callback onDrag para revisar que funciona
- modificando los callbacks onDragEnd y onClick para revisar los parámetros, todos deben recibir un objeto con formato { marker, prevMarker, instance }

## Changelog

**ADDED**
- marker ref, ref passed to handler events