### PR TITLE
JMV-3772-add-iconColor-prop-to-Chip-styles

### DIFF
--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -10,6 +10,7 @@ const Chip = ({
 	disabled,
 	icon,
 	iconColor,
+	iconSize,
 	onClick,
 	onDelete,
 	selected,
@@ -42,6 +43,7 @@ const Chip = ({
 					className="chip-icon"
 					name={icon}
 					color={iconColor}
+					size={iconSize}
 					pathStyles={styled.iconPathStyles}
 				/>
 			)}
@@ -74,6 +76,8 @@ Chip.propTypes = {
 	icon: PropTypes.string,
 	/** Permite modificar el color del icono */
 	iconColor: PropTypes.string,
+	/** Permite modificar el tamaño del icono */
+	iconSize: PropTypes.number,
 	/** Función a ejecutar al clickar */
 	onClick: PropTypes.func,
 	/** Función a ejecutar para borrar */

--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -6,7 +6,7 @@ import { mediaBreaks } from 'utils/devices';
 
 const getChipVariant = (props) => {
 	const { selected, color, sizeColor, variant } = props;
-	const variantStyles= {
+	const variantStyles = {
 		outlined: () => css`
 			border: 1px solid ${selected ? palette.blue : '#EAEBED'};
 			color: ${selected ? palette.blue : palette.black};
@@ -29,31 +29,31 @@ const getChipVariant = (props) => {
 		`,
 		contained: () => css`
 			background-color: ${selected ? palette.blue : palette.lightGreyHover};
-				color: ${selected ? palette.white : palette.black};
-					.chip-icon {
-						fill: ${selected ? palette.white : palette.black};
-					}
-					.delete-button {
-						fill: ${selected ? palette.white : palette.darkGrey};
-					}
-					&:hover {
-						background-color: ${selected ? palette.blueHover : palette.lightGrey};
-					}
-					&:hover .delete-button {
-						fill: ${selected ? palette.white : palette.black};
-					}
-					&:active {
-						background-color: ${palette.blue};
-						color: ${palette.white};
-					}
-					&:active .chip-icon,
-					&:active .delete-button {
-						fill: ${palette.white};
-					}
-					&:disabled {
-						fill: ${palette.grey};
-						color: ${palette.grey};
-					}
+			color: ${selected ? palette.white : palette.black};
+			.chip-icon {
+				fill: ${selected ? palette.white : palette.black};
+			}
+			.delete-button {
+				fill: ${selected ? palette.white : palette.darkGrey};
+			}
+			&:hover {
+				background-color: ${selected ? palette.blueHover : palette.lightGrey};
+			}
+			&:hover .delete-button {
+				fill: ${selected ? palette.white : palette.black};
+			}
+			&:active {
+				background-color: ${palette.blue};
+				color: ${palette.white};
+			}
+			&:active .chip-icon,
+			&:active .delete-button {
+				fill: ${palette.white};
+			}
+			&:disabled {
+				fill: ${palette.grey};
+				color: ${palette.grey};
+			}
 		`,
 		status: () => css`
 			background-color: ${getColor(color || 'grey')};
@@ -87,18 +87,18 @@ export default {
 		pointer-events: ${(props) => (props.clickable || props.hasLink ? 'auto' : 'none')};
 		white-space: nowrap;
 
+		${(props) => getChipVariant(props)};
+
 		.chip-icon {
 			${(props) => !props.onlyIcon && 'margin-right: 8px'};
+			${(props) => props.iconColor && `fill: ${getColor(props.iconColor)}`};
 		}
-
-		${(props) => getChipVariant(props)};
 
 		${(props) => props.styles};
 
 		${(props) => props.borderColor && `border: solid 1px ${getColor(props.borderColor)};`}
 
-		${(props) =>
-			props.backgroundColor && `background-color: ${getColor(props.backgroundColor)};`}
+		${(props) => props.backgroundColor && `background-color: ${getColor(props.backgroundColor)};`}
 
 		${(props) => props.textColor && `color: ${getColor(props.textColor)};`}
 


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3772

## Descripción del requerimiento
Se necesita agregar la prop iconSize en la hoja de estilos del componente Chip, ya que la misma se estaba pasando al styled componente pero no se estaba usando, este añadido sirve para tomar el color que viene desde afuera (Views por ej.) y aplicárselo al icono que está dentro del Chip (si es que hay).

## Descripción de la solución
Se agregó la línea `${(props) => props.iconColor && `fill: ${getColor(props.iconColor)}`};` dentro de la clase .chip-icon de la hoja de estilos del componente Chip, para poder aplicar un color si desde la prop iconColor llega un valor válido.

Se aprovecha este PR para agregar la prop `iconSize` y definir por fuera un tamaño para el icono del Chip.

## Cómo se puede probar?
Ingresar a la rama
Levantar el proyecto con `yarn storybook`
En el componente Chip, tomar cualquier caso y agregar un icono, un color y un tamaño para revisar que esta ultima propiedad se aplique correctamente

## Changelog

**ADDED**
- iconColor prop set in Chip styles, iconSize prop to Icon in Chip component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to customize the icon size in the Chip component with a new iconSize option.

- **Style**
  - Improved styling consistency and formatting for the Chip component.
  - Chip icons now support custom fill colors if specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->