### PR TITLE
JMV-3772-add-iconColor-prop-to-Chip-styles

### DIFF
--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -33,30 +33,15 @@ const Chip = ({
 			selected={selected}
 			textColor={textColor}
 			variant={variant}
-			iconColor={iconColor}
 			hasLink={hasLink}
 			onlyIcon={!children && icon}
 			{...props}
 		>
-			{icon && (
-				<Icon
-					className="chip-icon"
-					name={icon}
-					color={iconColor}
-					size={iconSize}
-					pathStyles={styled.iconPathStyles}
-				/>
-			)}
+			{icon && <Icon className="chip-icon" name={icon} color={iconColor} size={iconSize} />}
 			{children && <styled.Children>{children}</styled.Children>}
 			{onDelete && (
 				<styled.DeleteButton type="button" onClick={onDelete}>
-					<Icon
-						color="black"
-						pathStyles={styled.deleteButtonPathStyles}
-						className="delete-button"
-						name="cross_circle_flat"
-						size={16}
-					/>
+					<Icon color="black" className="delete-button" name="cross_circle_flat" size={16} />
 				</styled.DeleteButton>
 			)}
 		</styled.Chip>

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -10,6 +10,7 @@ const Chip = ({
 	disabled,
 	icon,
 	iconColor,
+	iconSize,
 	onClick,
 	onDelete,
 	selected,
@@ -42,6 +43,7 @@ const Chip = ({
 					className="chip-icon"
 					name={icon}
 					color={iconColor}
+					size={iconSize}
 					pathStyles={styled.iconPathStyles}
 				/>
 			)}
@@ -74,6 +76,8 @@ Chip.propTypes = {
 	icon: PropTypes.string,
 	/** Permite modificar el color del icono */
 	iconColor: PropTypes.string,
+	/** Permite modificar el tamaño del icono */
+	iconSize: PropTypes.number,
 	/** Función a ejecutar al clickar */
 	onClick: PropTypes.func,
 	/** Función a ejecutar para borrar */

--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 import palette from 'theme/palette';
 import { getColor } from 'theme/utils';
-import mixins from 'theme/mixins';
 import { mediaBreaks } from 'utils/devices';
 
 const getChipVariant = (props) => {
@@ -87,12 +86,11 @@ export default {
 		pointer-events: ${(props) => (props.clickable || props.hasLink ? 'auto' : 'none')};
 		white-space: nowrap;
 
-		${(props) => getChipVariant(props)};
-
 		.chip-icon {
 			${(props) => !props.onlyIcon && 'margin-right: 8px'};
-			${(props) => props.iconColor && `fill: ${getColor(props.iconColor)}`};
 		}
+
+		${(props) => getChipVariant(props)};
 
 		${(props) => props.styles};
 
@@ -106,16 +104,10 @@ export default {
 			border: 1px solid ${palette.darkGrey};
 		`}
 	`,
-	iconPathStyles: css`
-		${mixins.transition('fill')};
-	`,
 	DeleteButton: styled.button`
 		width: 16px;
 		height: 16px;
 		margin-left: 12px;
-	`,
-	deleteButtonPathStyles: css`
-		${mixins.transition('fill')};
 	`,
 	Children: styled.div`
 		text-overflow: ellipsis;

--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -6,7 +6,7 @@ import { mediaBreaks } from 'utils/devices';
 
 const getChipVariant = (props) => {
 	const { selected, color, sizeColor, variant } = props;
-	const variantStyles= {
+	const variantStyles = {
 		outlined: () => css`
 			border: 1px solid ${selected ? palette.blue : '#EAEBED'};
 			color: ${selected ? palette.blue : palette.black};
@@ -29,31 +29,31 @@ const getChipVariant = (props) => {
 		`,
 		contained: () => css`
 			background-color: ${selected ? palette.blue : palette.lightGreyHover};
-				color: ${selected ? palette.white : palette.black};
-					.chip-icon {
-						fill: ${selected ? palette.white : palette.black};
-					}
-					.delete-button {
-						fill: ${selected ? palette.white : palette.darkGrey};
-					}
-					&:hover {
-						background-color: ${selected ? palette.blueHover : palette.lightGrey};
-					}
-					&:hover .delete-button {
-						fill: ${selected ? palette.white : palette.black};
-					}
-					&:active {
-						background-color: ${palette.blue};
-						color: ${palette.white};
-					}
-					&:active .chip-icon,
-					&:active .delete-button {
-						fill: ${palette.white};
-					}
-					&:disabled {
-						fill: ${palette.grey};
-						color: ${palette.grey};
-					}
+			color: ${selected ? palette.white : palette.black};
+			.chip-icon {
+				fill: ${selected ? palette.white : palette.black};
+			}
+			.delete-button {
+				fill: ${selected ? palette.white : palette.darkGrey};
+			}
+			&:hover {
+				background-color: ${selected ? palette.blueHover : palette.lightGrey};
+			}
+			&:hover .delete-button {
+				fill: ${selected ? palette.white : palette.black};
+			}
+			&:active {
+				background-color: ${palette.blue};
+				color: ${palette.white};
+			}
+			&:active .chip-icon,
+			&:active .delete-button {
+				fill: ${palette.white};
+			}
+			&:disabled {
+				fill: ${palette.grey};
+				color: ${palette.grey};
+			}
 		`,
 		status: () => css`
 			background-color: ${getColor(color || 'grey')};
@@ -87,18 +87,18 @@ export default {
 		pointer-events: ${(props) => (props.clickable || props.hasLink ? 'auto' : 'none')};
 		white-space: nowrap;
 
+		${(props) => getChipVariant(props)};
+
 		.chip-icon {
 			${(props) => !props.onlyIcon && 'margin-right: 8px'};
+			${(props) => props.iconColor && `fill: ${getColor(props.iconColor)}`};
 		}
-
-		${(props) => getChipVariant(props)};
 
 		${(props) => props.styles};
 
 		${(props) => props.borderColor && `border: solid 1px ${getColor(props.borderColor)};`}
 
-		${(props) =>
-			props.backgroundColor && `background-color: ${getColor(props.backgroundColor)};`}
+		${(props) => props.backgroundColor && `background-color: ${getColor(props.backgroundColor)};`}
 
 		${(props) => props.textColor && `color: ${getColor(props.textColor)};`}
 

--- a/src/components/Icon/styles.js
+++ b/src/components/Icon/styles.js
@@ -12,6 +12,8 @@ const styles = {
 			fill: ${colors.darkGrey};
 		`}
 
+		${mixins.transition('fill')};
+
 		${(props) => props.styles};
 	`,
 	Path: styled.path`


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3772

## Descripción del requerimiento
Se necesita revertir los cambios hechos en [este PR](https://github.com/janis-commerce/ui-web/pull/68)

## Descripción de la solución
- Se eliminó la línea `${(props) => props.iconColor && fill: ${getColor(props.iconColor)}};` dentro de la clase .chip-icon de la hoja de estilos del componente Chip.
- Se removió la prop `iconColor` que se le estaba pasando a `styled.Chip` porque no se va a usar
- Se removieron los estilos de `iconPathStyles` y `deleteButtonPathStyles`, ambos estilos estaban declarando un mixin, se agregó el mismo estilo directamente en el componente Icon.
- Se agregó el caso WithoutVariant al story del Chip para poder aplicar un backgroundColor y un iconColor

## Cómo se puede probar?
Ingresar a la rama
Levantar el proyecto con `yarn storybook`
En el componente Chip, tomar cualquier caso y agregar un icono, un color y un tamaño para revisar que esta ultima propiedad se aplique correctamente.
También revisar el caso `WithoutVariant`, debe poder aplicarse un backgroundColor y un iconColor elegidos desde las opciones

## Changelog
ADDED
- fill transition mixin in Icon component styles
 
REMOVE
- iconColor prop in Chip styled component, pathStyles, iconPathStyles and deleteButtonPathStyles statements