### PR TITLE
fix: delete fixed maxwidth at chip to maxWidthProp

### DIFF
--- a/src/components/Chip/styles.js
+++ b/src/components/Chip/styles.js
@@ -78,7 +78,6 @@ export default {
 		height: ${(props) => (!props.onlyIcon ? '32px' : '36px')};
 		width: ${(props) => props.onlyIcon && '36px'};
 		min-width: 36px;
-		${(props) => props.maxWidth && `max-width: ${props.maxWidth}`};
 		border-radius: ${(props) => (!props.onlyIcon ? '50px' : '50%')};
 		display: inline-flex;
 		justify-content: center;


### PR DESCRIPTION
## Link al ticket

- https://janiscommerce.atlassian.net/browse/JMV-3905

## Descripción del requerimiento

- eliminar el max width del chip

## Criterios de aprobación

- El componente Chip no debe tener maxWidth 

## Descripción de la solución

- Se modificó el archivo `src/components/Chip/styles.js` para eliminar el valor fijo `max-width: 150px` 

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|--------------|-------------------|-------------------|---------------|
| Renderizar Chip | El chip debe comportarse sin restricción de ancho máximo | ✅ o ❌ | Verificar que no corte nunca 

## Evidencias, pruebas de cómo funciona

- Se puede verificar en Storybook navegando a Components/Chip y agregando texto al chip en los controles

## CHANGELOG:

```javascript
### Fixed
- Delete maxWidth in Chip component 
```
